### PR TITLE
gradients-texture-menu-animations

### DIFF
--- a/SDL2_gui/GUI_App.h
+++ b/SDL2_gui/GUI_App.h
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 #include <iostream>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include "SDL_gui.h"
 
 #define GUI_ORIENTATION_PORTRAIT    1
@@ -22,6 +22,32 @@
 #define GUI_APP_CONTENT_VIEW        4
 #define GUI_APP_MENU                8
 #define GUI_APP_MENUBAR             16
+#define GUI_APP_MENU_LEFT           32      // Button on the left animation from the left
+#define GUI_APP_MENU_LEFT_TOP       64      // Button on the left animation from the top
+#define GUI_APP_MENU_LEFT_BOTTOM    128      // Button on the left animation from the bottom
+#define GUI_APP_MENU_RIGHT          256     // Button on the right animation from the right
+#define GUI_APP_MENU_RIGHT_TOP      512     // Button on the right animation from the top
+#define GUI_APP_MENU_RIGHT_BOTTOM   1024    // Button on the right animation from the bottom
+
+#if defined( __ANDROID__ )
+static int _expectedWidth = 360;
+static int _expectedHeight = 600;
+#elif defined( __IPHONEOS__ )
+static int _expectedWidth = 360;
+static int _expectedHeight = 600;
+#elif defined( __MACOSX__ )
+static int _expectedWidth = 1024;
+static int _expectedHeight = 768;
+#elif defined( __WIN32__ )
+static int _expectedWidth = 1024;
+static int _expectedHeight = 768;
+#elif defined( __EMSCRIPTEN__ )
+static int _expectedWidth = 360;
+static int _expectedHeight = 600;
+#else
+static int _expectedWidth = 480;
+static int _expectedHeight = 800;
+#endif
 
 class GUI_View;
 class GUI_TopBar;
@@ -31,35 +57,35 @@ class GUI_Menu;
 class GUI_MenuBar;
 
 class GUI_App {
-private:
-    static GUI_App *instance;
 protected:
+    static GUI_App *instance;
+public:
     void createTopBar( int options );
     void createMenuBar( int options );
     void createStatusBar( int options );
     void createContentView( int options );
     void createMenu( int options );
-    
+
     bool isMenuShow;
 public:
     static GUI_App *create( std::string title, int expectedWidth=0, int expectedHeight=0, int Orientation=0, int options=0 );
     GUI_App( int Orientation, std::string title, int expectedWidth, int expectedHeight, int options=0 );
     virtual ~GUI_App();
-    
+
     std::string title;
     int width;
     int height;
     GUI_View *topView;
-    
+
     GUI_TopBar *topBar;
     GUI_StatusBar *statusBar;
     GUI_View *contentView;
     GUI_Button *menuButton;
     GUI_Menu *menuView;
     GUI_MenuBar *menuBar;
-    
+
     static GUI_App *getInstance() { return instance; };
-    
+
     void run();
 };
 

--- a/SDL2_gui/GUI_Button.cpp
+++ b/SDL2_gui/GUI_Button.cpp
@@ -23,10 +23,10 @@ GUI_Label(parent, title, unicode, x, y, width, height, NULL )
     focusable = true;
     showInteract = true;
     mouseReceive = true;
-    
+
     setBackgroundColor(cWhite);
     callback = callbackFunction;
-    
+
     setBorder( 1 );
     focusBorder = 2;
     setCorner( 4 );
@@ -40,18 +40,18 @@ GUI_Label(parent, title, unicode, x, y, width, height, NULL )
 }
 
 GUI_Button::~GUI_Button() {
-    
+
 }
 
 void GUI_Button::setEnable(bool e) {
     _enable = e;
     if( _enable ) {
-        textView->setTextColor(cBlack);
-        iconView->setTextColor(cBlack);
+        if(textView) textView->setTextColor(cBlack);
+        if(iconView) iconView->setTextColor(cBlack);
         setBorderColor(cBlack);
     } else {
-        textView->setTextColor(cGrey);
-        iconView->setTextColor(cGrey);
+        if(textView) textView->setTextColor(cGrey);
+        if(iconView) iconView->setTextColor(cGrey);
         setBorderColor(cGrey);
     }
 };

--- a/SDL2_gui/GUI_Config.h
+++ b/SDL2_gui/GUI_Config.h
@@ -10,7 +10,7 @@
 #define GUI_Config_h
 
 #include <string>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 //const std::string GUI_UIIconFontName = "fa-solid-900.ttf";
 

--- a/SDL2_gui/GUI_Fonts.h
+++ b/SDL2_gui/GUI_Fonts.h
@@ -12,17 +12,17 @@
 #include <stdio.h>
 #include <string>
 #include <map>
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 class GUI_Fonts {
 protected:
 
 public:
     static std::map<std::string, TTF_Font *> font_map;
-    
+
     GUI_Fonts();
     ~GUI_Fonts();
-    
+
     static TTF_Font *getFont( std::string fontName, int fontSize );
     static void clear();
 };

--- a/SDL2_gui/GUI_ImageView.h
+++ b/SDL2_gui/GUI_ImageView.h
@@ -13,8 +13,8 @@
 #include <stdio.h>
 #include <functional>
 #include <vector>
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
 #include "GUI_View.h"
 #include "GUI_Utils.h"
 #include "GUI_image.h"
@@ -23,7 +23,7 @@ class GUI_ImageView : public GUI_View {
 protected:
     GUI_image image;
     SDL_Color colorMod;
-    
+
     int contentScrollPosnX;
     int contentScrollPosnY;
 public:
@@ -32,10 +32,10 @@ public:
     GUI_ImageView(GUI_View *parent, const char *title, const char *filename=NULL, int x=0, int y=0, int width=0, int height=0,
                   std::function<bool(SDL_Event* ev)>userEventHandler = NULL);
     virtual ~GUI_ImageView();
-    
+
     void setColor( SDL_Color color );
     virtual void updateSize();
-    
+
     virtual void draw();
 };
 

--- a/SDL2_gui/GUI_List.h
+++ b/SDL2_gui/GUI_List.h
@@ -22,10 +22,10 @@ public:
     GUI_ListItem(GUI_View *parent, const char *title, int x=0, int y=0, int width=0, int height=0,
              std::function<void(GUI_View*)>callbackFunction = NULL );
     virtual ~GUI_ListItem();
-    
+
     virtual void setSelected( bool c );
     virtual bool isSelected() { return selected; };
-    
+
     virtual void postdraw();
 };
 
@@ -39,15 +39,15 @@ public:
     GUI_List(GUI_View *parent, const char *title, int x=0, int y=0, int width=0, int height=0,
                          std::function<void(GUI_View*)>callbackFunction = NULL );
     virtual ~GUI_List();
-    
+
     virtual void add(GUI_ListItem* child);
     virtual void remove(GUI_ListItem* child);
-    
+
     virtual void addSimpleItem( const char *title );
-    
+
     bool multiSelect;
-    
-    GUI_ListItem *selectedItem;
+
+    GUI_ListItem *selectedItem = nullptr;
     std::vector<GUI_ListItem *>selectedItems;
 };
 #endif /* GUI_List_hpp */

--- a/SDL2_gui/GUI_Menu.cpp
+++ b/SDL2_gui/GUI_Menu.cpp
@@ -8,6 +8,7 @@
 
 #include "GUI_Menu.h"
 #include "GUI_shapes.h"
+#include <iterator>
 
 GUI_MenuItem *GUI_MenuItem::create( GUI_View *parent, const char *title, int x, int y, int width, int height,
                                    std::function<void(GUI_View*)>callbackFunction ) {
@@ -27,15 +28,15 @@ separator(true)
     showInteract = true;
     mouseReceive = true;
     focusBorder = 0;
-    
+
     setBackgroundColor(cWhite);
-    
+
     setLayout(GUI_LAYOUT_HORIZONTAL);
     setBorder( 0 );
 }
 
 GUI_MenuItem::~GUI_MenuItem() {
-    
+
 }
 
 void GUI_MenuItem::setSelected( bool s ) {
@@ -50,7 +51,7 @@ void GUI_MenuItem::setSelected( bool s ) {
 
 void GUI_MenuItem::postdraw() {
     GUI_View::postdraw();
-    
+
     if( separator ) {
         GUI_DrawHLine( 0, rectView.w, rectView.h-1, cBlack );
     }
@@ -59,39 +60,44 @@ void GUI_MenuItem::postdraw() {
 // ------------------------------------------------------------------------------------------------
 
 GUI_Menu *GUI_Menu::create( GUI_View *parent, const char *title, int x, int y, int width, int height,
-                           std::function<void(GUI_View*)>callbackFunction ) {
-    return new GUI_Menu( parent, title, x, y, width, height, callbackFunction );
+                           std::function<void(GUI_View*)>callbackFunction, MenuAnimationMode mode ) {
+    return new GUI_Menu( parent, title, x, y, width, height, callbackFunction, mode );
 }
 
 GUI_Menu::GUI_Menu(GUI_View *parent, const char *title, int x, int y, int width, int height,
-                   std::function<void(GUI_View*)>callbackFunction ) :
+                   std::function<void(GUI_View*)>callbackFunction, MenuAnimationMode mode ) :
 GUI_View( parent, title, x, y, width, height ),
 isOpen(1)
 {
     clickable = false;
     capture_on_click = true;
-    
+
     setCallback( callbackFunction );
-    
+
     setAlign( GUI_ALIGN_ABSOLUTE );
-    
+
     setBackgroundColor(cEmptyContent);
     setLayout(GUI_LAYOUT_VERTICAL);
-    
+
     if( parent )
         parent->updateLayout();
+
+    setMenuAnimationMode(mode);
 }
 
 GUI_Menu::~GUI_Menu() {
-    
+
 }
 
 void GUI_Menu::add(GUI_MenuItem* child) {
     add_child(child);
-    
+
     menuItems.push_back(child);
     child->setCallback( [=](GUI_View *v) {
         GUI_MenuItem *lit = (GUI_MenuItem *)v;
+        int size(menuItems.size());
+        std::vector<GUI_MenuItem *> items(menuItems);
+        int i(0), dist(distance(menuItems.begin(), menuItems.end()));
         for (std::vector<GUI_MenuItem *>::iterator it = menuItems.begin() ; it != menuItems.end(); ++it) {
             GUI_MenuItem *c = *it;
             if( lit == c ) {
@@ -105,53 +111,61 @@ void GUI_Menu::add(GUI_MenuItem* child) {
             else {
                 c->setSelected(false);
             }
+            ++i;
         }
     });
 }
 
 void GUI_Menu::remove(GUI_MenuItem* child) {
     remove_child(child);
-    for (std::vector<GUI_MenuItem *>::iterator it = menuItems.begin() ; it != menuItems.end(); ++it) {
+    for (std::vector<GUI_MenuItem *>::iterator it = menuItems.begin() ; it != menuItems.end();) {
         if( child == *it ) {
-            menuItems.erase( it );
+            it = menuItems.erase( it );
             break;
         }
+        else
+            ++it;
     }
     child->setCallback(NULL);
 }
 
-void GUI_Menu::addSimpleMenu( const char *title, bool separator ) {
+GUI_MenuItem * GUI_Menu::addSimpleMenu( const char *title, bool separator ) {
     GUI_MenuItem *item1 = GUI_MenuItem::create( NULL, title, 0, 0, -1, 0 );
     item1->setPadding( 8, 10, 8, 10 );
     item1->separator = separator;
-    
+
     GUI_Label *lb1 = GUI_Label::create( item1, title, 0, 0, -1, 0 );
     lb1->setAlign( GUI_ALIGN_LEFT | GUI_ALIGN_VCENTER );
     lb1->setBackgroundColor(cClear);
-    
+
     add( item1 );
     updateLayout();
+    return item1;
 }
 
 void GUI_Menu::close( int duration ) {
     if( isMoving )
         return;
     isOpen = false;
-    moveTo( 0-GUI_GetAppMenuWidth(), getAbsolutePosition().y, duration );
+    moveTo(hiddenX, hiddenY, duration );
+//    moveTo( 0-GUI_GetAppMenuWidth(), getAbsolutePosition().y, duration );
 
     GUI_SetMouseCapture( NULL );
     //GUI_Log( "Menu close\n" );
-    
+
 }
 
 void GUI_Menu::open( int duration ) {
     if( isMoving )
         return;
+    if(selectedItem)
+        selectedItem->setSelected(false);
     isOpen = true;
 #ifdef __IPHONEOS__
     moveTo( getContentSaftyMargin()[3], getAbsolutePosition().y, duration );
 #else
-    moveTo( 0, getAbsolutePosition().y, duration );
+    moveTo(visibleX, visibleY, duration );
+        //moveTo(0, getAbsolutePosition().y, duration );
 #endif
 
     GUI_SetMouseCapture( this );
@@ -165,7 +179,7 @@ void GUI_Menu::predraw() {
 
 bool GUI_Menu::eventHandler(SDL_Event*event) {
     SDL_Scancode scancode;
-   
+
     switch (event->type) {
         case GUI_UpdateSize:
         {
@@ -174,6 +188,7 @@ bool GUI_Menu::eventHandler(SDL_Event*event) {
 #ifdef __IPHONEOS__
             ox = getContentSaftyMargin()[3];
 #endif
+            setMenuAnimationMode(menuAnimationMode);
             open();
             bool ret = GUI_View::eventHandler(event);
             close();
@@ -184,10 +199,10 @@ bool GUI_Menu::eventHandler(SDL_Event*event) {
         case SDL_FINGERUP:
         {
             SDL_TouchFingerEvent e = event->tfinger;
-            
+
             int x = (int)(e.x*GUI_windowWidth*GUI_mouseScale);
             int y = (int)(e.y*GUI_windowHeight*GUI_mouseScale);
-            
+
             if( isOpen ) {
                 if( activateView && event->type == SDL_FINGERDOWN) {
                     if( activateView->hitTest(x, y, false) ) {
@@ -205,7 +220,7 @@ bool GUI_Menu::eventHandler(SDL_Event*event) {
         case SDL_MOUSEBUTTONUP:
         {
             SDL_MouseButtonEvent e = event->button;
-            
+
             int x = (int)(e.x*GUI_mouseScale);
             int y = (int)(e.y*GUI_mouseScale);
 
@@ -223,12 +238,49 @@ bool GUI_Menu::eventHandler(SDL_Event*event) {
             }
             return GUI_View::eventHandler(event);
         }
-            
+
         default:
         {
             return GUI_View::eventHandler(event);
         }
     }
-     
+
     return false;
+}
+
+MenuAnimationMode GUI_Menu::getMenuAnimationMode()
+{
+    return menuAnimationMode;
+}
+
+void GUI_Menu::setMenuAnimationMode(MenuAnimationMode mode)
+{
+    menuAnimationMode = mode;
+    switch(menuAnimationMode)
+    {
+    case eFromLeft:
+        hiddenX = -GUI_GetAppMenuWidth();
+        hiddenY = getAbsolutePosition().y;
+        visibleX = 0;
+        visibleY = hiddenY;
+        break;
+    case eFromRight:
+        hiddenX = parent->getWidth() * GUI_scale;
+        hiddenY = getAbsolutePosition().y;
+        visibleX = (parent->getWidth() * GUI_scale) - GUI_GetAppMenuWidth();
+        visibleY = hiddenY;
+        break;
+    case eFromTop:
+        hiddenX = ((parent->getWidth() * GUI_scale) - GUI_GetAppMenuWidth()) / 2;
+        hiddenY = (- getHeight()) * GUI_scale;
+        visibleX = hiddenX;
+        visibleY = getAbsolutePosition().y * GUI_scale;
+        break;
+    case eFromBottom:
+        hiddenX = ((parent->getWidth() - getWidth()) / 2) * GUI_scale;
+        hiddenY = parent->getHeight() * GUI_scale;
+        visibleX = hiddenX;
+        visibleY = getAbsolutePosition().y;
+        break;
+    }
 }

--- a/SDL2_gui/GUI_Menu.h
+++ b/SDL2_gui/GUI_Menu.h
@@ -21,41 +21,55 @@ public:
     GUI_MenuItem(GUI_View *parent, const char *title, int x=0, int y=0, int width=0, int height=0,
                  std::function<void(GUI_View*)>callbackFunction = NULL );
     virtual ~GUI_MenuItem();
-    
+
     virtual void setSelected( bool c );
     virtual bool isSelected() { return selected; };
-    
+
     virtual void postdraw();
-    
+
     bool separator;
 };
 
+enum MenuAnimationMode
+{
+    eFromLeft,
+    eFromRight,
+    eFromBottom,
+    eFromTop
+};
+
 class GUI_Menu : public GUI_View {
-protected:
+public:
     std::vector<GUI_MenuItem *>menuItems;
-    
+protected:
     GUI_View    *activateView;
+    MenuAnimationMode menuAnimationMode = eFromLeft;
+    int hiddenX = 0, hiddenY = 0;
+    int visibleX = 0, visibleY = 0;
 public:
     static GUI_Menu *create( GUI_View *parent, const char *title, int x=0, int y=0, int width=0, int height=0,
-                            std::function<void(GUI_View*)>callbackFunction = NULL );
+                            std::function<void(GUI_View*)>callbackFunction = nullptr, MenuAnimationMode mode = eFromLeft );
     GUI_Menu(GUI_View *parent, const char *title, int x=0, int y=0, int width=0, int height=0,
-             std::function<void(GUI_View*)>callbackFunction = NULL );
+             std::function<void(GUI_View*)>callbackFunction = nullptr, MenuAnimationMode mode = eFromLeft );
     virtual ~GUI_Menu();
-    
+
     virtual bool eventHandler(SDL_Event*ev);
-    
+
     virtual void add(GUI_MenuItem* child);
     virtual void remove(GUI_MenuItem* child);
-    
-    virtual void addSimpleMenu( const char *title, bool separator=false );
-    
-    GUI_MenuItem *selectedItem;
-    
+
+    virtual GUI_MenuItem *addSimpleMenu( const char *title, bool separator=false );
+
+    GUI_MenuItem *selectedItem = nullptr;
+
     bool isOpen;
-    
+
+    MenuAnimationMode getMenuAnimationMode();
+    void setMenuAnimationMode(MenuAnimationMode mode);
+
     virtual void close( int duration=0 );
     virtual void open( int duration=0 );
-    
+
     virtual void predraw();
 
     void setActivateView( GUI_View *v ) { activateView = v; };

--- a/SDL2_gui/GUI_TextUtil.cpp
+++ b/SDL2_gui/GUI_TextUtil.cpp
@@ -9,9 +9,9 @@
 #include "GUI_TextUtil.h"
 #include <string>
 #include "GUI_Utils.h"
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 /*
- 
+
  Each byte starts with a few bits that tell you whether it's a single byte code-point, a multi-byte code point, or a continuation of a multi-byte code point. Like this:
  0xxx xxxx    A single-byte US-ASCII code (from the first 127 characters)
  The multi-byte code-points each start with a few bits that essentially say "hey, you need to also read the next byte (or two, or three) to figure out what I am." They are:
@@ -21,7 +21,7 @@
  Finally, the bytes that follow those start codes all look like this:
  10xx xxxx    A continuation of one of the multi-byte characters
  Since you can tell what kind of byte you're looking at from the first few bits, then even if something gets mangled somewhere, you don't lose the whole sequence.
- 
+
  Ref: https://stackoverflow.com/questions/1543613/how-does-utf-8-variable-width-encoding-work
  */
 
@@ -134,7 +134,7 @@ int GUI_GetNextMainUTF8Index( std::string str, int i ) {
     if( i >= 0 && i < str.length() ) {
         int byte;
         int nextI;
-        
+
         byte = GUI_GetUnicodeAtIndex( str, i, &nextI );
         i = nextI;
         while( i < str.length() ) {

--- a/SDL2_gui/GUI_TextUtil.h
+++ b/SDL2_gui/GUI_TextUtil.h
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 #include <string>
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 int GUI_GetPreviousUTF8Index( std::string str, int index );
 int GUI_GetPreviousMainUTF8Index( std::string str, int index );

--- a/SDL2_gui/GUI_Utils.h
+++ b/SDL2_gui/GUI_Utils.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <stdio.h>
 #include <functional>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include "GUI_Config.h"
 
 class GUI_View;
@@ -99,6 +99,23 @@ extern "C" int *getContentSaftyMargin();
 
 #ifdef __EMSCRIPTEN__
 inline bool SDL_IsTablet() { return true; };
+#endif
+
+SDL_Color GUI_TranslateColor(Uint32 int_color);
+
+enum ScreenShotType
+{
+    ePng,
+    eJpg,
+    eRaw
+};
+
+void GUI_MakeRendererScreenshot(SDL_Renderer* renderer, std::string fileName, ScreenShotType type = ePng);
+
+#if defined(WIN32) || defined(_WIN32)
+#define PATH_SEPARATOR "\\"
+#else
+#define PATH_SEPARATOR "/"
 #endif
 
 #endif /* GUI_Utils_hpp */

--- a/SDL2_gui/GUI_View.cpp
+++ b/SDL2_gui/GUI_View.cpp
@@ -89,10 +89,10 @@ textSelectionEndIndex(0)
     oy = y;
     ow = w;
     oh = h;
-    
+
     setBorder(1);
     setCorner(0);
-    
+
     if (t) {
         title = std::string(t);
     }
@@ -103,9 +103,9 @@ textSelectionEndIndex(0)
 
 GUI_View::~GUI_View() {
     //GUI_Log( "Kill %s\n", title.c_str() );
-    
+
     delete_all_children();
-    
+
     if( parent ) {
         parent->remove_child(this);
     }
@@ -124,10 +124,10 @@ void GUI_View::update() {
         }
         int x = moveOriginX + ((moveTargetX-moveOriginX) * (float)moveTime / (float)moveDuration);
         int y = moveOriginY + ((moveTargetY-moveOriginY) * (float)moveTime / (float)moveDuration);
-        
+
         int dx = x - topLeft.x;
         int dy = y - topLeft.y;
-        
+
         move_topLeft( dx, dy );
     }
 }
@@ -150,10 +150,10 @@ bool GUI_View::eventHandler(SDL_Event*event) {
             rectView.y = oy * GUI_scale;
             rectView.w = ow == -1 ? ow : ow * GUI_scale;
             rectView.h = oh == -1 ? oh : oh * GUI_scale;
-            
+
             setSaftyPadding();
             setSaftyMargin();
-            
+
             if( parent ) {
                 parent->updateLayout();
             }
@@ -194,7 +194,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
             //GUI_Log( "Finger DOWN %s\n", title.c_str() );
             SDL_TouchFingerEvent e = event->tfinger;
             SDL_FingerID fid = e.fingerId;
-            
+
             int x = (int)(e.x*GUI_windowWidth*GUI_mouseScale);
             int y = (int)(e.y*GUI_windowHeight*GUI_mouseScale);
 
@@ -257,7 +257,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
             //GUI_Log( "Mouse DOWN %s\n", title.c_str() );
 
             SDL_MouseButtonEvent e = event->button;
-            
+
             int x = (int)(e.x*GUI_mouseScale);
             int y = (int)(e.y*GUI_mouseScale);
 
@@ -268,7 +268,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 break;
             }
             ReverseRecursive = true;
-            
+
             if( hitTest(x, y, false) ) {
                 //GUI_Log( "Hit %s\n", title.c_str() );
                 if( mouseReceive ) {
@@ -320,18 +320,18 @@ bool GUI_View::eventHandler(SDL_Event*event) {
             SDL_TouchFingerEvent e = event->tfinger;
             SDL_FingerID fid = e.fingerId;
             //GUI_Log( "%i\n", fid );
-            
+
             int x = (int)(e.x*GUI_windowWidth*GUI_mouseScale);
             int y = (int)(e.y*GUI_windowHeight*GUI_mouseScale);
-            
+
             if( !mouseReceive ) {
                 BreakRecursive = true;
                 BreakSiblingPropagate = false;
                 break;
             }
-            
+
             ReverseRecursive = true;
-            
+
             if (_dragging) {
                 //GUI_Log( "Finger DRAGGING %s\n", title.c_str() );
                 if (parent) {
@@ -346,17 +346,17 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 if( drag_limit ) {
                     int tlX = topLeft.x + dx;
                     int tlY = topLeft.y + dy;
-                    
+
                     if( tlY < dragMinY * GUI_scale )
                         tlY = dragMinY * GUI_scale;
                     if( tlY > dragMaxY * GUI_scale )
                         tlY = dragMaxY * GUI_scale;
-                    
+
                     if( tlX < dragMinX * GUI_scale )
                         tlX = dragMinX * GUI_scale;
                     if( tlX > dragMaxX * GUI_scale )
                         tlX = dragMaxX * GUI_scale;
-                    
+
                     dy = tlY - topLeft.y;
                     dx = tlX - topLeft.x;
                 }
@@ -385,7 +385,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                     }
                 }
                 //GUI_Log( "Mouse motion %s\n", title.c_str() );
-                
+
                 BreakSiblingPropagate = true;
                 setInteract( true );
                 if( parent ) {
@@ -403,10 +403,10 @@ bool GUI_View::eventHandler(SDL_Event*event) {
         case SDL_MOUSEMOTION:
         {
             SDL_MouseMotionEvent e = event->motion;
-            
+
             int x = (int)(e.x*GUI_mouseScale);
             int y = (int)(e.y*GUI_mouseScale);
-            
+
             if( !mouseReceive ) {
                 BreakRecursive = true;
                 BreakSiblingPropagate = false;
@@ -429,17 +429,17 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 if( drag_limit ) {
                     int tlX = topLeft.x + dx;
                     int tlY = topLeft.y + dy;
-                    
+
                     if( tlY < dragMinY * GUI_scale )
                         tlY = dragMinY * GUI_scale;
                     if( tlY > dragMaxY * GUI_scale )
                         tlY = dragMaxY * GUI_scale;
-                    
+
                     if( tlX < dragMinX * GUI_scale )
                         tlX = dragMinX * GUI_scale;
                     if( tlX > dragMaxX * GUI_scale )
                         tlX = dragMaxX * GUI_scale;
-                    
+
                     dy = tlY - topLeft.y;
                     dx = tlX - topLeft.x;
                 }
@@ -493,7 +493,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
             //SDL_MouseButtonEvent e = event->button;
             int x = (int)(e.x*GUI_windowWidth*GUI_mouseScale);
             int y = (int)(e.y*GUI_windowHeight*GUI_mouseScale);
-            
+
             if( !mouseReceive ) {
                 BreakRecursive = true;
                 BreakSiblingPropagate = false;
@@ -506,7 +506,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 GUI_SetMouseCapture(NULL);
                 return true;
             }
-            
+
             if( hitTest(x, y, false) ) {
                 //GUI_Log( "Finger UP IN %s\n", title.c_str() );
                 BreakSiblingPropagate = true;
@@ -545,7 +545,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 }
                 BreakRecursive = true;
             }
-            
+
             break;
         }
 #endif
@@ -556,7 +556,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
             SDL_MouseButtonEvent e = event->button;
             int x = (int)(e.x*GUI_mouseScale);
             int y = (int)(e.y*GUI_mouseScale);
-            
+
             if( !mouseReceive ) {
                 BreakRecursive = true;
                 BreakSiblingPropagate = false;
@@ -569,7 +569,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 GUI_SetMouseCapture(NULL);
                 return true;
             }
-            
+
             if( hitTest(x, y, false) ) {
                 //GUI_Log( "Mouse UP IN %s\n", title.c_str() );
                 BreakSiblingPropagate = true;
@@ -608,7 +608,7 @@ bool GUI_View::eventHandler(SDL_Event*event) {
                 }
                 BreakRecursive = true;
             }
-            
+
             break;
         }
 #endif
@@ -654,15 +654,15 @@ bool GUI_View::eventHandler(SDL_Event*event) {
 void GUI_View::move_topLeft(int dx, int dy) {
     topLeft.x += dx;
     topLeft.y += dy;
-    
+
     rectView.x += dx;
     rectView.y += dy;
-    
+
     if( _align & GUI_ALIGN_ABSOLUTE ) {
         //ox = topLeft.x;
         //oy = topLeft.y;
     }
-    
+
     for (int it = 0 ; it < children.size(); ++it) {
         GUI_View *child = children[it];
         child->move_rectView(dx, dy);
@@ -672,7 +672,7 @@ void GUI_View::move_topLeft(int dx, int dy) {
 void GUI_View::move_rectView(int dx, int dy) {
     rectView.x += dx;
     rectView.y += dy;
-    
+
     for (int it = 0 ; it < children.size(); ++it) {
         GUI_View *child = children[it];
         child->move_rectView(dx, dy);
@@ -697,7 +697,7 @@ void GUI_View::move( int dx, int dy, int time ) {
 void GUI_View::moveTo( int x, int y, int time ) {
     int dx = x - rectView.x / GUI_scale;
     int dy = y - rectView.y / GUI_scale;
-    
+
     move( dx, dy, time );
 }
 
@@ -706,9 +706,9 @@ void GUI_View::add_child(GUI_View *child) {
         child->parent->remove_child( child );
     }
     child->parent = this;
-    
+
     children.push_back(child);
-    
+
     updateLayout();
 }
 
@@ -752,13 +752,13 @@ void GUI_View::predraw() {
     int f = 0;
     if( isFocus() && focusBorder > 0 ) {
         f = focusBorder * GUI_scale;
-        
+
         if (parent) {
             GUI_Rect parent_clip = GUI_Rect(parent->rectClip);
             parent_clip.x -= topLeft.x;
             parent_clip.y -= topLeft.y;
             SDL_IntersectRect(GUI_MakeRect(0, 0, rectView.w+(f*2), rectView.h+(f*2)), &parent_clip, &rectClip);
-            
+
             // Bug of SDL
             if (rectClip.w < 0)
                 rectClip.w = 0;
@@ -767,16 +767,16 @@ void GUI_View::predraw() {
         } else {
             rectClip = GUI_Rect(0, 0, rectView.w, rectView.h);
         }
-        
+
 #ifdef __EMSCRIPTENx__
         SDL_RenderSetViewport(GUI_renderer, GUI_MakeRect(rectView.x, GUI_windowHeight*GUI_scale - rectView.y - rectView.h, rectView.w, rectView.h));
 #else
         SDL_RenderSetViewport(GUI_renderer, GUI_MakeRect(rectView.x-f, rectView.y-f, rectView.w+(f*2), rectView.h+(f*2)));
 #endif
-        
+
 #ifdef __EMSCRIPTENx__
         float magic_y = GUI_windowHeight*GUI_scale - rectView.y - rectView.h;
-        
+
         SDL_RenderSetClipRect(GUI_renderer, GUI_MakeRect(rectView.x + rectClip.x,
                                                          0 - magic_y + rectClip.y,
                                                          rectClip.w,
@@ -789,13 +789,13 @@ void GUI_View::predraw() {
 #endif
         drawFocus();
     }
-    
+
     if (parent) {
         GUI_Rect parent_clip = GUI_Rect(parent->rectClip);
         parent_clip.x -= topLeft.x;
         parent_clip.y -= topLeft.y;
         SDL_IntersectRect(GUI_MakeRect(0, 0, rectView.w, rectView.h), &parent_clip, &rectClip);
-        
+
         // Bug of SDL
         if (rectClip.w < 0)
             rectClip.w = 0;
@@ -813,7 +813,7 @@ void GUI_View::predraw() {
 
 #ifdef __EMSCRIPTENx__
     float magic_y = GUI_windowHeight*GUI_scale - rectView.y - rectView.h;
-    
+
     SDL_RenderSetClipRect(GUI_renderer, GUI_MakeRect(rectView.x + rectClip.x,
                                                      0 - magic_y + rectClip.y,
                                                      rectClip.w,
@@ -834,7 +834,7 @@ void GUI_View::draw() {
 void GUI_View::drawInteract() {
     if( showInteract && getInteract() ) {
         GUI_Rect *rect = GUI_MakeRect(0, 0, rectView.w, rectView.h);
-        
+
         if (getCorner() != 0) {
             GUI_FillRoundRect(rect->x, rect->y, rect->w, rect->h, getCorner() * GUI_scale, cHightLightInteract);
         } else {
@@ -847,21 +847,21 @@ void GUI_View::postdraw() {
     drawInteract();
     int border = getBorder();
     int corner = getCorner();
-    
+
     if (border > 0) {
         GUI_Rect r = GUI_Rect(border, border, rectView.w - (2 * border), rectView.h - (2 * border));
-        
+
         if (corner) {
             GUI_DrawRoundRect(0, 0, rectView.w, rectView.h, corner * GUI_scale, _borderColor);
         } else {
             GUI_DrawRect(0, 0, rectView.w, rectView.h, _borderColor);
         }
-        
+
         SDL_IntersectRect(&r, &rectClip, &rectClip);
-        
+
 #ifdef __EMSCRIPTENx__
         float magic_y = GUI_windowHeight*GUI_scale - rectView.y - rectView.h;
-        
+
         SDL_RenderSetClipRect(GUI_renderer, GUI_MakeRect(rectView.x + rectClip.x,
                                                          0 - magic_y + rectClip.y,
                                                          rectClip.w,
@@ -879,14 +879,37 @@ void GUI_View::postdraw() {
 void GUI_View::clear(GUI_Rect *rect) {
     if (!rect)
         rect = GUI_MakeRect(0, 0, rectView.w, rectView.h);
-    
-    if (_backgroundColor.a != 0) {
-        int corner = getCorner();
-        if (corner != 0) {
-            GUI_FillRoundRect(rect->x, rect->y, rect->w, rect->h, corner * GUI_scale, _backgroundColor);
-        } else {
+
+    int corner(getCorner());
+    if(mBackgroundMode == eSolidColor)
+    {
+        if(_backgroundColor.a == 0)
+            return;
+        if(!corner)
             GUI_FillRect(rect->x, rect->y, rect->w, rect->h, _backgroundColor);
-        }
+        else
+            GUI_FillRoundRect(rect->x, rect->y, rect->w, rect->h, corner * GUI_scale, _backgroundColor);
+    }
+    else if(mBackgroundMode & eHorizontalLinearGradient)
+    {
+        if(!corner)
+            GUI_FillRectWithGradientHorizontal(rect, _backgroundGradientColor1, _backgroundGradientColor2);
+        else
+            GUI_FillRectWithGradientHorizontal(rect, _backgroundGradientColor1, _backgroundGradientColor2, corner * GUI_scale);
+    }
+    else if(mBackgroundMode & eVerticalLinearGradient)
+    {
+        if(!corner)
+            GUI_FillRectWithGradientVertical(rect, _backgroundGradientColor1, _backgroundGradientColor2);
+        else
+            GUI_FillRectWithGradientVertical(rect, _backgroundGradientColor1, _backgroundGradientColor2, corner * GUI_scale);
+    }
+    else if(mBackgroundMode & eTexture)
+    {
+        if(!corner)
+            GUI_FillRectWithTexture(rect, _backgroundTexture);
+        else
+            GUI_FillRectWithTexture(rect, _backgroundTexture, corner * GUI_scale);
     }
 }
 
@@ -895,9 +918,9 @@ void GUI_View::drawFocus() {
         return;
     if (focusBorder <= 0 )
         return;
-    
+
     GUI_Rect *rect = GUI_MakeRect(0, 0, rectView.w+(focusBorder*GUI_scale*2), rectView.h+(focusBorder*GUI_scale*2));
-    
+
     if (_backgroundColor.a != 0) {
         SDL_Color color = _backgroundColor;
         color.a = 96;
@@ -916,7 +939,7 @@ void GUI_View::drawFocus() {
 bool GUI_View::toTop() {
     if( !parent )
         return false;
-    
+
     for (int it = 0 ; it < parent->children.size(); ++it) {
         if( this == parent->children[it] ) {
             parent->children.erase(parent->children.begin() + it );
@@ -930,7 +953,7 @@ bool GUI_View::toTop() {
 bool GUI_View::toBack() {
     if( !parent )
         return false;
-    
+
     for (int it = 0 ; it < parent->children.size(); ++it) {
         if( this == parent->children[it] ) {
             parent->children.erase(parent->children.begin()+ it );
@@ -989,7 +1012,7 @@ void GUI_View::setPadding(int p0, int p1, int p2, int p3) {
     _padding[1] = p1;
     _padding[2] = p2;
     _padding[3] = p3;
-    
+
     updateSize();
     this->updateLayout();
 }
@@ -999,7 +1022,7 @@ void GUI_View::setMargin(int p0, int p1, int p2, int p3) {
     _margin[1] = p1;
     _margin[2] = p2;
     _margin[3] = p3;
-    
+
     if (parent) {
         parent->updateLayout();
         updateLayout();
@@ -1012,11 +1035,11 @@ GUI_View *GUI_View::hitTest(int x, int y, bool bRecursive) {
         //GUI_Log( "Invisible %s\n", title.c_str() );
         return 0;
     }
-    
+
     SDL_Point pt;
     pt.x = x;
     pt.y = y;
-    
+
     if (SDL_PointInRect(&pt, &rectView)) {
         // GUI_Log( "Hit in %s\n", title.c_str() );
         if (bRecursive) {
@@ -1024,7 +1047,7 @@ GUI_View *GUI_View::hitTest(int x, int y, bool bRecursive) {
                 for (int it = children.size()-1 ; it >= 0; --it) {
                     GUI_View *child = children[it];
                     //GUI_Log( "Hit2\n" );
-                    
+
                     GUI_View *wb = child->hitTest(x, y, bRecursive);
                     if (wb) {
                         //GUI_Log( "Hitted %s\n", wb->title.c_str());
@@ -1044,17 +1067,17 @@ void GUI_View::updateSize() {
 void GUI_View::updateLayout() {
     //GUI_Log( "UpdateLayout %s\n", title.c_str() );
     updateSize();
-    
+
     if( this == GUI_topView ) {
         if (ox == 0)
             rectView.x = _margin[3] * GUI_scale;
-        
+
         if (oy == 0)
             rectView.y = _margin[0] * GUI_scale;
-        
+
         if (ow == -1)
             rectView.w = (GUI_windowWidth - _margin[1]) * GUI_scale - rectView.x;
-        
+
         if (oh == -1)
             rectView.h = (GUI_windowHeight - _margin[0]) * GUI_scale - rectView.y;
     }
@@ -1062,10 +1085,10 @@ void GUI_View::updateLayout() {
         bool sz_changed = false;
         for (std::vector<GUI_View *>::iterator it = children.begin() ; it != children.end(); ++it) {
             GUI_View *child = *it;
-            
+
             if (child->isVisible() == false)
                 continue;
-            
+
             if (child->_align & GUI_ALIGN_RIGHT) {
                 child->topLeft.x = rectView.w - child->rectView.w - (child->_margin[1] + _padding[1]) * GUI_scale;
                 child->rectView.x = rectView.x + child->topLeft.x;
@@ -1083,23 +1106,23 @@ void GUI_View::updateLayout() {
                         child->topLeft.x = child->ox * GUI_scale;
                     }
                 }
-                
+
                 child->rectView.x = rectView.x + child->topLeft.x;
-                
+
                 if (child->ow == -1) {
                     child->rectView.w = rectView.w - child->topLeft.x - (child->_margin[1] + _padding[1]) * GUI_scale;
                 }
             }
-            
+
             if (ow == 0) {
                 int wwx = (child->rectView.w + (_padding[1] + _padding[3] + child->_margin[1] + child->_margin[3])*GUI_scale); // + (border * 2);
-                
+
                 if (wwx != rectView.w) {
                     rectView.w = wwx;
                     sz_changed = true;
                 }
             }
-            
+
             if (child->_align & GUI_ALIGN_BOTTOM) {
                 child->topLeft.y = rectView.h - child->rectView.h - (child->_margin[2] + _padding[2]) * GUI_scale;
                 child->rectView.y = rectView.y + child->topLeft.y;
@@ -1117,23 +1140,23 @@ void GUI_View::updateLayout() {
                         child->topLeft.y = child->oy * GUI_scale;
                     }
                 }
-                
+
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 if (child->oh == -1) {
                     child->rectView.h = rectView.h - child->topLeft.y - (child->_margin[2] + _padding[2]) * GUI_scale;
                 }
             }
-            
+
             if (oh == 0) {
                 int hhx = (child->rectView.h + (_padding[0] + _padding[2] + child->_margin[0] + child->_margin[2])*GUI_scale); // + (border * 2);
-                
+
                 if (hhx != rectView.h) {
                     rectView.h = hhx;
                     sz_changed = true;
                 }
             }
-            
+
             if (ow == 0 || oh == 0) {
                 if (sz_changed) {
                     int oww = ow;
@@ -1141,41 +1164,41 @@ void GUI_View::updateLayout() {
                     ow = rectView.w;
                     oh = rectView.h;
                     //updateSubLayout();
-                    
+
                     if (_align & (GUI_ALIGN_CENTER | GUI_ALIGN_RIGHT | GUI_ALIGN_BOTTOM | GUI_ALIGN_VCENTER)) {
                         if (parent) {
                             parent->updateLayout();
                         }
                     }
-                    
+
                     ow = oww;
                     oh = ohh;
                 }
             }
-            
+
             child->updateLayout();
         }
     }
     if (_layout == GUI_LAYOUT_HORIZONTAL) {
         int x = 0;
-        
+
         x += _padding[3] * GUI_scale;
-        
+
         int w = 0;
         int h = 0;
-        
+
         for (int it = 0 ; it < children.size(); ++it) {
             GUI_View *child = children[it];
-            
+
             if (child->isVisible() == false)
                 continue;
-            
+
             if (child->_align & GUI_ALIGN_ABSOLUTE) {
                 //child->topLeft.x = child->ox * GUI_scale;
                 //child->topLeft.y = child->oy * GUI_scale;
                 child->rectView.x = rectView.x + child->topLeft.x;
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 if (child->oh == -1) {
                     child->rectView.h = rectView.h - (_padding[2] + child->_margin[2] + _padding[0] + child->_margin[0]) * GUI_scale;
                 }
@@ -1185,13 +1208,13 @@ void GUI_View::updateLayout() {
             } else if (child->_align & GUI_ALIGN_CENTER) {
                 child->topLeft.x = (rectView.w - child->rectView.w) / 2;
                 child->rectView.x = rectView.x + child->topLeft.x;
-                
+
                 for (int iit = it-1; iit >= 0; --iit) {
                     GUI_View *cc = children[iit];
-                    
+
                     if (cc->isVisible() == false)
                         continue;
-                    
+
                     if (cc->_align & GUI_ALIGN_CENTER) {
                         cc->topLeft.x -= child->rectView.w / 2 + ((child->_margin[3] + cc->_margin[1]) * GUI_scale) / 2;
                         cc->rectView.x = rectView.x + cc->topLeft.x;
@@ -1203,17 +1226,17 @@ void GUI_View::updateLayout() {
             } else if (child->_align & GUI_ALIGN_RIGHT) {
                 child->topLeft.x = (rectView.w - child->rectView.w) - ((child->_margin[1] + _padding[1]) * GUI_scale);
                 child->rectView.x = rectView.x + child->topLeft.x;
-                
+
                 for (int iit = it-1; iit >= 0; --iit) {
                     GUI_View *cc = children[iit];
-                    
+
                     if (cc->isVisible() == false)
                         continue;
-                    
+
                     if (cc->_align & GUI_ALIGN_RIGHT) {
                         cc->topLeft.x -= child->rectView.w + (child->_margin[1] + child->_margin[3]) * GUI_scale;
                         cc->rectView.x = rectView.x + cc->topLeft.x;
-                        
+
                         cc->updateLayout();
                     } else if (cc->_align & GUI_ALIGN_CENTER) {
                     } else {
@@ -1229,17 +1252,17 @@ void GUI_View::updateLayout() {
             } else {
                 child->topLeft.x = x + child->_margin[3] * GUI_scale;
                 child->rectView.x = rectView.x + child->topLeft.x;
-                
+
                 if (child->ow == -1) {
                     child->rectView.w = rectView.w - child->topLeft.x - (_padding[1] + child->_margin[1])* GUI_scale;
                 }
                 else {
                     for (int iit = it-1; iit >= 0; --iit) {
                         GUI_View *cc = children[iit];
-                        
+
                         if (cc->isVisible() == false)
                             continue;
-                        
+
                         if (cc->_align & GUI_ALIGN_RIGHT) {
                         } else if (cc->_align & GUI_ALIGN_CENTER) {
                         } else {
@@ -1265,17 +1288,17 @@ void GUI_View::updateLayout() {
                         }
                     }
                 }
-                
+
                 x += child->rectView.w + (child->_margin[1] + child->_margin[3]) * GUI_scale;
             }
-            
+
             w += child->rectView.w + (child->_margin[3] + child->_margin[1]) * GUI_scale;
-            
+
             int hh = child->rectView.h + (child->_margin[0] + child->_margin[2]) * GUI_scale;
             if( hh > h ) {
                 h = hh;
             }
-            
+
             if (child->_align & GUI_ALIGN_ABSOLUTE) {
             } else if (child->_align & GUI_ALIGN_BOTTOM) {
                 child->topLeft.y = rectView.h - child->rectView.h - (_padding[2] + child->_margin[2])*GUI_scale;
@@ -1286,7 +1309,7 @@ void GUI_View::updateLayout() {
             } else {
                 child->topLeft.y = (_padding[0] + child->_margin[0]) * GUI_scale;
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 if (child->oh == -1) {
                     child->rectView.h = rectView.h - (_padding[0] + child->_margin[0] + _padding[2] + child->_margin[2]) * GUI_scale;
                 }
@@ -1313,24 +1336,24 @@ void GUI_View::updateLayout() {
         }
     } else if (_layout == GUI_LAYOUT_VERTICAL) {
         int y = 0;
-        
+
         y += _padding[0] * GUI_scale;
-        
+
         int w = 0;
         int h = 0;
-        
+
         for (int it = 0 ; it < children.size(); ++it) {
             GUI_View *child = children[it];
-            
+
             if (child->isVisible() == false)
                 continue;
-            
+
             if (child->_align & GUI_ALIGN_ABSOLUTE) {
                 //child->topLeft.x = child->ox * GUI_scale;
                 //child->topLeft.y = child->oy * GUI_scale;
                 child->rectView.x = rectView.x + child->topLeft.x;
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 if (child->oh == -1) {
                     child->rectView.h = rectView.h - (_padding[2] + child->_margin[2] + _padding[0] + child->_margin[0]) * GUI_scale;
                 }
@@ -1340,13 +1363,13 @@ void GUI_View::updateLayout() {
             } else if (child->_align & GUI_ALIGN_VCENTER) {
                 child->topLeft.y = (rectView.h - child->rectView.h) / 2;
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 for (int iit = it-1; iit >= 0; --iit) {
                     GUI_View *cc = children[iit];
-                    
+
                     if (cc->isVisible() == false)
                         continue;
-                    
+
                     if (cc->_align & GUI_ALIGN_VCENTER) {
                         cc->topLeft.y -= child->rectView.h / 2 + ((child->_margin[0] + cc->_margin[2]) * GUI_scale) / 2;
                         cc->rectView.y = rectView.y + cc->topLeft.y;
@@ -1358,17 +1381,17 @@ void GUI_View::updateLayout() {
             } else if (child->_align & GUI_ALIGN_BOTTOM) {
                 child->topLeft.y = (rectView.h - child->rectView.h) - ((child->_margin[2] + _padding[2]) * GUI_scale);
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 for (int iit = it-1; iit >= 0; --iit) {
                     GUI_View *cc = children[iit];
-                    
+
                     if (cc->isVisible() == false)
                         continue;
-                    
+
                     if (cc->_align & GUI_ALIGN_BOTTOM) {
                         cc->topLeft.y -= child->rectView.h + (child->_margin[0] + child->_margin[2]) * GUI_scale;
                         cc->rectView.y = rectView.y + cc->topLeft.y;
-                        
+
                         cc->updateLayout();
                     } else if (cc->_align & GUI_ALIGN_VCENTER) {
                     } else {
@@ -1384,17 +1407,17 @@ void GUI_View::updateLayout() {
             } else {
                 child->topLeft.y = y + child->_margin[0] * GUI_scale;
                 child->rectView.y = rectView.y + child->topLeft.y;
-                
+
                 if (child->oh == -1) {
                     child->rectView.h = rectView.h - child->topLeft.y - (_padding[2] + child->_margin[2])* GUI_scale;
                 }
                 else {
                     for (int iit = it-1; iit >= 0; --iit) {
                         GUI_View *cc = children[iit];
-                        
+
                         if (cc->isVisible() == false)
                             continue;
-                        
+
                         if (cc->_align & GUI_ALIGN_BOTTOM) {
                         } else if (cc->_align & GUI_ALIGN_VCENTER) {
                         } else {
@@ -1420,7 +1443,7 @@ void GUI_View::updateLayout() {
                         }
                     }
                 }
-                
+
                 y += child->rectView.h + (child->_margin[0] + child->_margin[2]) * GUI_scale;
             }
 
@@ -1430,7 +1453,7 @@ void GUI_View::updateLayout() {
             if( ww > w ) {
                 w = ww;
             }
-            
+
             if (child->_align & GUI_ALIGN_ABSOLUTE) {
 
             } else if (child->_align & GUI_ALIGN_RIGHT) {
@@ -1442,7 +1465,7 @@ void GUI_View::updateLayout() {
             } else {
                 child->topLeft.x = (_padding[3] + child->_margin[3]) * GUI_scale;
                 child->rectView.x = rectView.x + child->topLeft.x;
-                
+
                 if (child->ow == -1) {
                     child->rectView.w = rectView.w - (_padding[1] + child->_margin[1] + _padding[3] + child->_margin[3]) * GUI_scale;
                 }
@@ -1473,16 +1496,16 @@ void GUI_View::updateLayout() {
 void GUI_View::setAbsolutePosition( int x, int y, int duration ) {
     int dx = x - rectView.x/GUI_scale;
     int dy = y - rectView.y/GUI_scale;
-        
+
     move( dx, dy, duration );
 }
 
 GUI_Point GUI_View::getAbsolutePosition() {
     static GUI_Point pt;
-    
+
     pt.x = rectView.x / GUI_scale;
     pt.y = rectView.y / GUI_scale;
-    
+
     return pt;
 }
 
@@ -1542,13 +1565,13 @@ void GUI_View::setSaftyPadding() {
 #else
     int saftyPaddings[4] = { 0, 0, 0, 0 };
 #endif
-    
+
     if( _saftyPaddingFlag ) {
         if( _saftyPaddingFlag & 1 ) { _padding[0] = saftyPaddings[0]; }
         if( _saftyPaddingFlag & 2 ) { _padding[1] = saftyPaddings[1]; }
         if( _saftyPaddingFlag & 4 ) { _padding[2] = saftyPaddings[2]; }
         if( _saftyPaddingFlag & 8 ) { _padding[3] = saftyPaddings[3]; }
-        
+
         if (parent) {
             parent->updateLayout();
             updateLayout();

--- a/SDL2_gui/GUI_image.h
+++ b/SDL2_gui/GUI_image.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <stdio.h>
 #include <functional>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include "GUI_Utils.h"
 
 class GUI_image {

--- a/SDL2_gui/GUI_shapes.cpp
+++ b/SDL2_gui/GUI_shapes.cpp
@@ -8,19 +8,20 @@
 
 #include "SDL_gui.h"
 #include "GUI_shapes.h"
-#include <SDL.h>
+#include <SDL2/SDL.h>
+#include <fstream>
 
 static SDL_Texture *drawCircle[24] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 static SDL_Texture *fillCircle[24] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
 void GUI_FillRect(SDL_Renderer * renderer, int x, int y, int w, int h, SDL_Color col) {
     SDL_Rect rect = {x, y, w, h};
-    
+
     int result = 0;
     result |= SDL_SetRenderDrawBlendMode(renderer, (col.a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
     result |= SDL_SetRenderDrawColor(renderer, col.r, col.g, col.b, col.a);
     result |= SDL_RenderFillRect(renderer, &rect);
-    
+
     if (result)
         GUI_Error("GUI_FillRect", result);
 }
@@ -31,12 +32,12 @@ void GUI_FillRect(int x, int y, int w, int h, SDL_Color col) {
 
 void GUI_DrawRect(SDL_Renderer * renderer, int x, int y, int w, int h, SDL_Color col) {
     SDL_Rect rect = {x, y, w, h};
-    
+
     int result = 0;
     result |= SDL_SetRenderDrawBlendMode(renderer, (col.a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
     result |= SDL_SetRenderDrawColor(renderer, col.r, col.g, col.b, col.a);
     result |= SDL_RenderDrawRect(renderer, &rect);
-    
+
     if (result)
         GUI_Error("GUI_DrawRect", result);
 }
@@ -49,15 +50,15 @@ SDL_Texture *getDrawTexture( int radius ) {
 #if defined(__WIN32__) || defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__ANDROID__)
     return NULL;
 #else
-    
+
     // Only __EMSCRIPTEN__ and __RPI__
-    
+
     if( radius <= 1 || radius >= 24 )
         return NULL;
     if( drawCircle[radius] ) {
         return drawCircle[radius];
     }
-    
+
     SDL_Texture *tex = SDL_CreateTexture(GUI_renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, radius*2+1, radius*2+1);
     drawCircle[radius] = tex;
     SDL_SetRenderTarget(GUI_renderer, drawCircle[radius]);
@@ -68,7 +69,7 @@ SDL_Texture *getDrawTexture( int radius ) {
     int result = circleRGBA(GUI_renderer, radius, radius, radius, cWhite.r, cWhite.g, cWhite.b, cWhite.a);
     if( result )
         return NULL;
-    
+
     SDL_SetRenderTarget(GUI_renderer, NULL);
 
     return drawCircle[radius];
@@ -79,26 +80,26 @@ SDL_Texture *getFillTexture( int radius ) {
 #if defined(__WIN32__) || defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__ANDROID__)
     return NULL;
 #else
-    
+
     // Only __EMSCRIPTEN__ and __RPI__
-    
+
     if( radius <= 1 || radius >= 24 )
         return NULL;
     if( fillCircle[radius] ) {
         return fillCircle[radius];
     }
-    
+
     SDL_Texture *tex = SDL_CreateTexture(GUI_renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, radius*2+1, radius*2+1);
     fillCircle[radius] = tex;
     SDL_SetRenderTarget(GUI_renderer, fillCircle[radius]);
     SDL_SetTextureBlendMode(fillCircle[radius], SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawColor(GUI_renderer, 0, 0, 0, 0);
     SDL_RenderClear(GUI_renderer);
-    
+
     int result = filledCircleRGBA(GUI_renderer, radius, radius, radius, cWhite.r, cWhite.g, cWhite.b, cWhite.a);
-    
+
     SDL_SetRenderTarget(GUI_renderer, NULL);
-    
+
     if( result )
         return NULL;
     return fillCircle[radius];
@@ -155,16 +156,16 @@ void GUI_DrawRoundRect(SDL_Renderer * renderer, int x, int y, int w, int h, int 
         radius = w / 2;
     if ((radius * 2) > h)
         radius = h / 2;
-    
+
     if( radius <= 2 ) {
         return GUI_DrawRect( renderer, x, y, w, h, col );
     }
-    
+
     SDL_Texture *tex = getDrawTexture(radius);
     if( tex ) {
         SDL_SetTextureColorMod(tex, col.r, col.g, col.b);
         SDL_SetTextureAlphaMod(tex, col.a);
-        
+
         GUI_DrawHLine( x+radius, x+w-radius, y+0, col );
         GUI_DrawHLine( x+radius, x+w-radius, y+h-1, col );
         GUI_DrawVLine( x+0, y+radius, y+h-radius, col );
@@ -179,11 +180,11 @@ void GUI_DrawRoundRect(SDL_Renderer * renderer, int x, int y, int w, int h, int 
     }
     else {
         int result = roundedRectangleRGBA(renderer, x, y, x + w - 1, y + h - 1, radius, col.r, col.g, col.b, col.a);
-        
+
         if (result)
             GUI_Error("GUI_FillRoundRect", result);
     }
-    
+
 }
 
 void GUI_DrawRoundRect(int x, int y, int w, int h, int radius, SDL_Color c) {
@@ -195,20 +196,20 @@ void GUI_FillRoundRect(SDL_Renderer * renderer, int x, int y, int w, int h, int 
         radius = w / 2;
     if ((radius * 2) > h)
         radius = h / 2;
-    
+
     if( radius <= 2 ) {
         return GUI_FillRect( renderer, x, y, w, h, col );
     }
-    
+
     SDL_Texture *tex = getFillTexture(radius);
     if( tex ) {
         SDL_SetTextureColorMod(tex, col.r, col.g, col.b);
         SDL_SetTextureAlphaMod(tex, col.a);
-        
+
         GUI_FillRect(renderer, radius, 0, w-radius*2, radius, col );
         GUI_FillRect(renderer, 0, radius, w, h-radius*2, col );
         GUI_FillRect(renderer, radius, h-radius, w-radius*2, radius, col );
-        
+
         SDL_Rect src = { 0, 0, radius, radius };
         SDL_Rect dst = { 0, 0, radius, radius };
         src.x = 0; src.y = 0; dst.x = x; dst.y = y; SDL_RenderCopy(GUI_renderer, tex, &src, &dst);
@@ -218,7 +219,7 @@ void GUI_FillRoundRect(SDL_Renderer * renderer, int x, int y, int w, int h, int 
     }
     else {
         int result = roundedBoxRGBA(renderer, x, y, x + w - 1, y + h - 1, radius, col.r, col.g, col.b, col.a);
-        
+
         if (result)
             GUI_Error("GUI_FillRoundRect", result);
     }
@@ -226,6 +227,288 @@ void GUI_FillRoundRect(SDL_Renderer * renderer, int x, int y, int w, int h, int 
 
 void GUI_FillRoundRect(int x, int y, int w, int h, int radius, SDL_Color c) {
     GUI_FillRoundRect(GUI_renderer, x, y, w, h, radius, c );
+}
+
+void filledCircleRGBAPixels(int radius, SDL_Color& circleColor, std::vector<Uint32>& pixels, Uint32& transparent)
+{
+    SDL_Color backgroundColor; backgroundColor.r = 0; backgroundColor.g = 0; backgroundColor.b = 0; backgroundColor.a = 0;
+
+    SDL_Texture *tex(getFillTexture(radius));
+    if(!tex) SDL_LogError(0, SDL_GetError());
+
+    int result(0);
+    result = SDL_SetRenderTarget(GUI_renderer, tex);
+    if(result) SDL_LogError(0, SDL_GetError());
+
+    Uint32 format(0);
+    result = SDL_QueryTexture(tex, &format, nullptr, nullptr, nullptr);
+    if(result) SDL_LogError(0, SDL_GetError());
+    SDL_PixelFormat* mappingFormat(SDL_AllocFormat(format));
+    if(!mappingFormat) SDL_LogError(0, SDL_GetError());
+    transparent = SDL_MapRGBA(mappingFormat, backgroundColor.r, backgroundColor.g, backgroundColor.b, backgroundColor.a);
+
+    Uint32 pitch((radius * 2 + 1) * sizeof (Uint32));
+    SDL_Rect rect; rect.x = 0; rect.y = 0; rect.w = radius * 2 + 1; rect.h = radius * 2 + 1;
+    pixels.resize(pitch/4 * (radius * 2 + 1));
+    result = SDL_RenderReadPixels(GUI_renderer, &rect, format, pixels.data(), pitch);
+    if(result) SDL_LogError(0, SDL_GetError());
+
+    result = SDL_SetRenderTarget(GUI_renderer, NULL);
+    if(result) SDL_LogError(0, SDL_GetError());
+}
+
+void GUI_FillRectWithGradientHorizontal(GUI_Rect* rect, SDL_Color c1, SDL_Color c2, int radius)
+{
+    int x(0), y(0), width(rect->w), height(rect->h);
+    Uint8 r, g, b;
+    SDL_Rect dest;
+
+    Uint32 transparent(0);
+    SDL_Color circleColor(cWhite);
+    std::vector<Uint32> pixels;
+
+    if(radius)
+        filledCircleRGBAPixels(radius, circleColor, pixels, transparent);
+
+    for (; x < width; ++x)
+    {
+        r = (c2.r * x / width) + (c1.r * (width - x) / width);
+        g = (c2.g * x / width) + (c1.g * (width - x) / width);
+        b = (c2.b * x / width) + (c1.b * (width - x) / width);
+
+        dest.x = x;
+        dest.y = 0;
+        dest.w = 1;
+        dest.h = height;
+
+        if(radius && (dest.x <= radius))
+            while(true)
+            {
+                if(pixels[dest.y * (radius * 2 + 1) + dest.x] != transparent)
+                    break;
+                ++dest.y;
+                dest.h -= 2;
+            }
+        if(radius && (dest.x >= (width - radius)))
+            while(true)
+            {
+                if(pixels[dest.y * (radius * 2 + 1) + dest.x - (width - radius - 1) + radius] != transparent)
+                    break;
+                ++dest.y;   // Not needed?!?
+                dest.h -= 2;    // -- instead?!?
+            }
+
+      int result = 0;
+      result |= SDL_SetRenderDrawBlendMode(GUI_renderer, (c1.a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
+      result |= SDL_SetRenderDrawColor(GUI_renderer, r, g, b, 255);
+      result |= SDL_RenderFillRect(GUI_renderer, &dest);
+
+      if (result)
+          GUI_Error("GUI_FillRect", result);
+    }
+}
+
+void GUI_FillRectWithGradientVertical(GUI_Rect* rect, SDL_Color c1, SDL_Color c2, int radius)
+{
+    int x(0), y(0), width(rect->w), height(rect->h);
+    Uint8 r, g, b;
+    SDL_Rect dest;
+
+    Uint32 transparent(0);
+    SDL_Color circleColor(cBlack);
+    std::vector<Uint32> pixels;
+
+    if(radius)
+        filledCircleRGBAPixels(radius, circleColor, pixels, transparent);
+
+    for(; y < height; ++y)
+    {
+        r = (c2.r * y / height) + (c1.r * (height - y) / height);
+        g = (c2.g * y / height) + (c1.g * (height - y) / height);
+        b = (c2.b * y / height) + (c1.b * (height - y) / height);
+
+        dest.x = 0;
+        dest.y = y;
+        dest.w = width;
+        dest.h = 1;
+
+        if(radius && (dest.y <= radius))
+            while(true)
+            {
+                if(pixels[dest.y * (radius * 2 + 1) + dest.x] != transparent)
+                    break;
+                ++dest.x;
+                dest.w -= 2;
+            }
+        if(radius && (dest.y >= (height - radius - 1)))
+            while(true)
+            {
+                if(pixels[(dest.y - (height - radius - 1) + radius) * (radius * 2 + 1) + dest.x] != transparent)
+                    break;
+                ++dest.x;   // Not needed?!?
+                dest.w -= 2;    // -- instead?!?
+            }
+        int result = 0;
+        result |= SDL_SetRenderDrawBlendMode(GUI_renderer, (c1.a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
+        result |= SDL_SetRenderDrawColor(GUI_renderer, r, g, b, 255);
+        result |= SDL_RenderFillRect(GUI_renderer, &dest);
+
+        if (result)
+          GUI_Error("GUI_FillRect", result);
+    }
+}
+
+void GUI_FillRectWithTexture(GUI_Rect* rect, SDL_Texture* texture, int radius)
+{
+    int result(0);
+    int w(0), h(0);
+    result = SDL_QueryTexture(texture, nullptr, nullptr, &w, &h);
+    if(result) SDL_LogError(0, SDL_GetError());
+
+    Uint32 transparent(0);
+    SDL_Color circleColor(cBlack);
+    std::vector<Uint32> pixels;
+
+    if(radius)
+        filledCircleRGBAPixels(radius, circleColor, pixels, transparent);
+#ifdef DEBUG
+                int lBottomIndex(0);
+#endif
+    SDL_Rect src; src.x = 0; src.y = 0; src.w = w; src.h = h;
+    SDL_Rect dest; dest.x = 0; dest.y = 0; dest.w = src.w; dest.h = src.h;
+    bool partial(false);
+    for(int y(0); y < rect->h; y += h)
+    {
+        dest.y = y;
+        for(int x(0); x < rect->w - 1;)
+        {
+            if(!radius)
+            {
+                dest.x = x;
+                SDL_RenderCopy(GUI_renderer, texture, &src, &dest);
+                x += w;
+                continue;
+            }
+
+            while(x < radius)
+            {
+                src.x = x; src.y = 0; src.w = 1; src.h = h;
+                dest.x = x; dest.y = y; dest.w = 1; dest.h = h;
+                if(y < radius)
+                    while(pixels[src.y * (radius * 2 + 1) + x] == transparent)
+                    {
+                        ++dest.y;
+                        --dest.h;
+                        ++src.y;
+                        --src.h;
+                    }
+                if(((y + dest.y + dest.h) >= (rect->h - radius)))
+                {
+                    if((y + dest.y + dest.h) >= (rect->h))
+                    {
+                        dest.h -= (y + dest.y + dest.h) - (rect->h);
+                        src.h = dest.h;
+                    }
+#ifdef DEBUG
+                    lBottomIndex = (radius + radius - (rect->h - (y + dest.y + dest.h))) * (radius * 2 + 1) + x;
+#endif
+
+                    while(pixels[(radius + radius - (rect->h - (y + + dest.y + dest.h))) * (radius * 2 + 1) + x] == transparent)
+//                    while(pixels[(radius /*<- this because we check below part of pixel cirle*/ + y + src.h - (rect->h - radius)) * (radius * 2 + 1) + x] == transparent)
+                    {
+                        --dest.h;
+                        --src.h;
+                        if(!src.h)
+                            break;
+                    }
+#ifdef DEBUG
+                    lBottomIndex = (radius + radius - (rect->h - (y + dest.y + dest.h))) * (radius * 2 + 1) + x;
+#endif
+                }
+                SDL_RenderCopy(GUI_renderer, texture, &src, &dest);
+                ++x;
+                if(!partial) partial = true;
+            }
+
+            if(partial)
+                { src.x = radius; src.y = 0; src.w = w - radius; src.h = h; }
+            else
+                { src.x = 0; src.y = 0; src.h = h; src.w = w; }
+            dest.x = x; dest.y = y; dest.w = w; dest.h = h;
+
+            if(partial) partial = false;
+
+            if(x + src.w >= rect->w - radius)
+            {
+                partial = true;
+                src.w -= (x + src.w - (rect->w - radius));
+                dest.w = src.w;
+                SDL_RenderCopy(GUI_renderer, texture, &src, &dest);
+                x += src.w;
+
+                src.x += src.w;
+                src.w = w;
+                if(src.x + 1 >= src.w)
+                    src.x = 0;
+                dest.x = x;
+                dest.w = src.w;
+            }
+            else
+            {
+                SDL_RenderCopy(GUI_renderer, texture, &src, &dest);
+                x += src.w;
+                src.x = 0; src.y = 0; src.w = w; src.h = h;
+                dest.x = x; dest.y = y; dest.w = w; dest.h = h;
+            }
+
+            if(partial) partial = false;
+
+            while(((rect->w - (x + 1)) <= radius) && ((rect->w - (x + 1)) > 0))
+            {
+                src.y = 0; src.w = 1; src.h = h;
+                dest.w = 1; dest.h = h;
+                if(dest.y < radius)
+                    while(pixels[dest.y * (radius * 2 + 1) + radius + radius - (rect->w - (x + 1))] == transparent)
+                    {
+                        ++dest.y;
+                        --dest.h;
+                        ++src.y;
+                        --src.h;
+                    }
+                if(((y + dest.y + dest.h) >= (rect->h - radius)))
+                {
+                    if((y + dest.y + dest.h) >= (rect->h))
+                    {
+                        dest.h -= (y + dest.y + dest.h) - (rect->h);
+                        src.h = dest.h;
+                    }
+#ifdef DEBUG
+                    lBottomIndex = (radius + radius - (rect->h - (y + dest.y + dest.h))) * (radius * 2 + 1) + radius + radius + 1 - (rect->w - (x + 1)) - 1;
+#endif
+                    while(pixels[(radius + radius - (rect->h - (y + dest.y + dest.h))) * (radius * 2 + 1) + radius + radius + 1 - (rect->w - (x + 1)) - 1] == transparent)
+                    {
+#ifdef DEBUG
+                        lBottomIndex = (radius + radius - (rect->h - (y + dest.y + dest.h))) * (radius * 2 + 1) + radius + radius + 1 - (rect->w - (x + 1)) - 1;
+#endif
+                        --dest.h;
+                        --src.h;
+                        if(!dest.h)
+                            break;
+                    }
+                }
+
+                SDL_RenderCopy(GUI_renderer, texture, &src, &dest);
+                ++dest.x;
+                dest.y = y;
+                dest.h = h;
+                ++src.x;
+                src.y = y;
+                src.h = h;
+
+                ++x;
+            }
+        }
+    }
 }
 
 void GUI_DrawHLine( int x1, int x2, int y, SDL_Color color ) {

--- a/SDL2_gui/GUI_shapes.h
+++ b/SDL2_gui/GUI_shapes.h
@@ -10,6 +10,8 @@
 #define GUI_shapes_hpp
 
 #include <stdio.h>
+#include <SDL2/SDL.h>
+#include "GUI_Utils.h"
 
 void GUI_FillRect(int x, int y, int w, int h, SDL_Color col);
 void GUI_DrawRect(int x, int y, int w, int h, SDL_Color col);
@@ -19,6 +21,11 @@ void GUI_DrawCircle(int cx, int cy, int radius, SDL_Color col);
 
 void GUI_DrawRoundRect(int x, int y, int w, int h, int radius, SDL_Color col);
 void GUI_FillRoundRect(int x, int y, int w, int h, int radius, SDL_Color col);
+
+void GUI_FillRectWithGradientHorizontal(GUI_Rect* rect, SDL_Color c1, SDL_Color c2, int radius = 0);
+void GUI_FillRectWithGradientVertical(GUI_Rect* rect, SDL_Color c1, SDL_Color c2, int radius = 0);
+
+void GUI_FillRectWithTexture(GUI_Rect* rect, SDL_Texture* texture, int radius = 0);
 
 void GUI_DrawHLine( int x1, int x2, int y, SDL_Color color );
 void GUI_DrawVLine( int x, int y1, int y2, SDL_Color color );

--- a/SDL2_gui/SDL_gui.h
+++ b/SDL2_gui/SDL_gui.h
@@ -9,9 +9,9 @@
 #ifndef SDL_gui_hpp
 #define SDL_gui_hpp
 
-#include <SDL.h>
-#include <SDL_image.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_ttf.h>
 #include <stdio.h>
 #include <iostream>
 

--- a/tests/0010_SDL_image/_iOS/iOS.xcodeproj/project.pbxproj
+++ b/tests/0010_SDL_image/_iOS/iOS.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 					38CA5C9B1BCCAF2B0099BC3B = {
 						CreatedOnToolsVersion = 7.0.1;
 						DevelopmentTeam = 3M3W4L293S;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -256,7 +256,6 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -469,7 +468,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 3M3W4L293S;
 				ENABLE_TESTABILITY = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -483,10 +482,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.jimmysoftware.sdl-image";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jimmysoftware.$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = SDL_image;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = JimmyDev2019;
 				SDL_IMAGE_ROOT = ../../../SDL2_image;
 				SDL_ROOT = ../../../SDL2;
 			};
@@ -499,7 +498,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 3M3W4L293S;
 				GCC_PREPROCESSOR_DEFINITIONS = "__IPHONEOS__=1";
 				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]" = "__IPHONEOS__=1";
@@ -508,10 +507,10 @@
 				INFOPLIST_FILE = iOS/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.jimmysoftware.sdl-image";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jimmysoftware.$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = SDL_image;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = JimmyDist2019;
 				SDL_IMAGE_ROOT = ../../../SDL2_image;
 				SDL_ROOT = ../../../SDL2;
 			};

--- a/tests/0020_SDL_ttf/_cmake/modules/FindSDL2_IMAGE.cmake
+++ b/tests/0020_SDL_ttf/_cmake/modules/FindSDL2_IMAGE.cmake
@@ -41,7 +41,7 @@
 # module with the minor edit of changing "SDL" to "SDL2" where necessary. This
 # was not created for redistribution, and exists temporarily pending official
 # SDL2 CMake modules.
-# 
+#
 # Note that on windows this will only search for the 32bit libraries, to search
 # for 64bit change x86/i686-w64 to x64/x86_64-w64
 
@@ -89,70 +89,69 @@
 # License text for the above reference.)
 
 FIND_PATH(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
-	HINTS
-	${SDL2}
-	$ENV{SDL2}
-	$ENV{SDL2_IMAGE}
-	PATH_SUFFIXES include/SDL2 include SDL2
-	i686-w64-mingw32/include/SDL2
-	x86_64-w64-mingw32/include/SDL2
-	PATHS
-	~/Library/Frameworks
-	/Library/Frameworks
-	/usr/local/include/SDL2
-	/usr/include/SDL2
-	/sw # Fink
-	/opt/local # DarwinPorts
-	/opt/csw # Blastwave
-	/opt
+    HINTS
+    ${SDL2}
+    $ENV{SDL2}
+    $ENV{SDL2_IMAGE}
+    PATH_SUFFIXES include/SDL2 include SDL2
+    i686-w64-mingw32/include/SDL2
+    x86_64-w64-mingw32/include/SDL2
+    PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /usr/local/include/SDL2
+    /usr/include/SDL2
+    /sw # Fink
+    /opt/local # DarwinPorts
+    /opt/csw # Blastwave
+    /opt
 )
 
 # Lookup the 64 bit libs on x64
 IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
-		NAMES SDL2_image
-		HINTS
-		${SDL2}
-		$ENV{SDL2}
-		$ENV{SDL2_IMAGE}
-		PATH_SUFFIXES lib64 lib
-		lib/x64
-		x86_64-w64-mingw32/lib
-		PATHS
-		/sw
-		/opt/local
-		/opt/csw
-		/opt
-	)
+    FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
+        NAMES SDL2_image
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_IMAGE}
+        PATH_SUFFIXES lib64 lib
+        lib/x64
+        x86_64-w64-mingw32/lib
+        PATHS
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+    )
 # On 32bit build find the 32bit libs
-ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
-		NAMES SDL2_image
-		HINTS
-		${SDL2}
-		$ENV{SDL2}
-		$ENV{SDL2_IMAGE}
-		PATH_SUFFIXES lib
-		lib/x86
-		i686-w64-mingw32/lib
-		PATHS
-		/sw
-		/opt/local
-		/opt/csw
-		/opt
-	)
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
+        NAMES SDL2_image
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_IMAGE}
+        PATH_SUFFIXES lib
+        lib/x86
+        i686-w64-mingw32/lib
+        PATHS
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+    )
 ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 SET(SDL2_IMAGE_FOUND "NO")
-	IF(SDL2_IMAGE_LIBRARY_TEMP)
-	# Set the final string here so the GUI reflects the final state.
-	SET(SDL2_IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARY_TEMP} CACHE STRING "Where the SDL2_image Library can be found")
-	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
-	SET(SDL2_IMAGE_LIBRARY_TEMP "${SDL2_IMAGE_LIBRARY_TEMP}" CACHE INTERNAL "")
-	SET(SDL2_IMAGE_FOUND "YES")
+    IF(SDL2_IMAGE_LIBRARY_TEMP)
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2_IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARY_TEMP} CACHE STRING "Where the SDL2_image Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2_IMAGE_LIBRARY_TEMP "${SDL2_IMAGE_LIBRARY_TEMP}" CACHE INTERNAL "")
+    SET(SDL2_IMAGE_FOUND "YES")
 ENDIF(SDL2_IMAGE_LIBRARY_TEMP)
 
 INCLUDE(FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_IMAGE REQUIRED_VARS SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)
-

--- a/tests/0020_SDL_ttf/_cmake/modules/FindSDL2_TTF.cmake
+++ b/tests/0020_SDL_ttf/_cmake/modules/FindSDL2_TTF.cmake
@@ -41,7 +41,7 @@
 # module with the minor edit of changing "SDL" to "SDL2" where necessary. This
 # was not created for redistribution, and exists temporarily pending official
 # SDL2 CMake modules.
-# 
+#
 # Note that on windows this will only search for the 32bit libraries, to search
 # for 64bit change x86/i686-w64 to x64/x86_64-w64
 
@@ -89,69 +89,68 @@
 # License text for the above reference.)
 
 FIND_PATH(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
-	HINTS
-	${SDL2}
-	$ENV{SDL2}
-	$ENV{SDL2_TTF}
-	PATH_SUFFIXES include/SDL2 include SDL2
-	i686-w64-mingw32/include/SDL2
-	PATHS
-	~/Library/Frameworks
-	/Library/Frameworks
-	/usr/local/include/SDL2
-	/usr/include/SDL2
-	/sw # Fink
-	/opt/local # DarwinPorts
-	/opt/csw # Blastwave
-	/opt
+    HINTS
+    ${SDL2}
+    $ENV{SDL2}
+    $ENV{SDL2_TTF}
+    PATH_SUFFIXES include/SDL2 include SDL2
+    i686-w64-mingw32/include/SDL2
+    PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /usr/local/include/SDL2
+    /usr/include/SDL2
+    /sw # Fink
+    /opt/local # DarwinPorts
+    /opt/csw # Blastwave
+    /opt
 )
 
 # Lookup the 64 bit libs on x64
 IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	FIND_LIBRARY(SDL2_TTF_LIBRARY_TEMP
-		NAMES SDL2_ttf
-		HINTS
-		${SDL2}
-		$ENV{SDL2}
-		$ENV{SDL2_TTF}
-		PATH_SUFFIXES lib64 lib
-		lib/x64
-		x86_64-w64-mingw32/lib
-		PATHS
-		/sw
-		/opt/local
-		/opt/csw
-		/opt
-	)
+    FIND_LIBRARY(SDL2_TTF_LIBRARY_TEMP
+        NAMES SDL2_ttf
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_TTF}
+        PATH_SUFFIXES lib64 lib
+        lib/x64
+        x86_64-w64-mingw32/lib
+        PATHS
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+    )
 # On 32bit build find the 32bit libs
-ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	FIND_LIBRARY(SDL2_TTF_LIBRARY_TEMP
-		NAMES SDL2_ttf
-		HINTS
-		${SDL2}
-		$ENV{SDL2}
-		$ENV{SDL2_TTF}
-		PATH_SUFFIXES lib
-		lib/x86
-		i686-w64-mingw32/lib
-		PATHS
-		/sw
-		/opt/local
-		/opt/csw
-		/opt
-	)
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    FIND_LIBRARY(SDL2_TTF_LIBRARY_TEMP
+        NAMES SDL2_ttf
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_TTF}
+        PATH_SUFFIXES lib
+        lib/x86
+        i686-w64-mingw32/lib
+        PATHS
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+    )
 ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 SET(SDL2_TTF_FOUND "NO")
-	IF(SDL2_TTF_LIBRARY_TEMP)
-	# Set the final string here so the GUI reflects the final state.
-	SET(SDL2_TTF_LIBRARY ${SDL2_TTF_LIBRARY_TEMP} CACHE STRING "Where the SDL2_ttf Library can be found")
-	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
-	SET(SDL2_TTF_LIBRARY_TEMP "${SDL2_TTF_LIBRARY_TEMP}" CACHE INTERNAL "")
-	SET(SDL2_TTF_FOUND "YES")
+    IF(SDL2_TTF_LIBRARY_TEMP)
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2_TTF_LIBRARY ${SDL2_TTF_LIBRARY_TEMP} CACHE STRING "Where the SDL2_ttf Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2_TTF_LIBRARY_TEMP "${SDL2_TTF_LIBRARY_TEMP}" CACHE INTERNAL "")
+    SET(SDL2_TTF_FOUND "YES")
 ENDIF(SDL2_TTF_LIBRARY_TEMP)
 
 INCLUDE(FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_TTF REQUIRED_VARS SDL2_TTF_LIBRARY SDL2_TTF_INCLUDE_DIR)
-

--- a/tests/0020_SDL_ttf/_cmake/modules/FindSDL2_net.cmake
+++ b/tests/0020_SDL_ttf/_cmake/modules/FindSDL2_net.cmake
@@ -41,7 +41,7 @@
 # module with the minor edit of changing "SDL" to "SDL2" where necessary. This
 # was not created for redistribution, and exists temporarily pending official
 # SDL2 CMake modules.
-# 
+#
 # Note that on windows this will only search for the 32bit libraries, to search
 # for 64bit change x86/i686-w64 to x64/x86_64-w64
 
@@ -89,69 +89,68 @@
 # License text for the above reference.)
 
 FIND_PATH(SDL2_NET_INCLUDE_DIR SDL_net.h
-	HINTS
-	${SDL2}
-	$ENV{SDL2}
-	$ENV{SDL2_NET}
-	PATH_SUFFIXES include/SDL2 include SDL2
-	i686-w64-mingw32/include/SDL2
-	PATHS
-	~/Library/Frameworks
-	/Library/Frameworks
-	/usr/local/include/SDL2
-	/usr/include/SDL2
-	/sw # Fink
-	/opt/local # DarwinPorts
-	/opt/csw # Blastwave
-	/opt
+    HINTS
+    ${SDL2}
+    $ENV{SDL2}
+    $ENV{SDL2_NET}
+    PATH_SUFFIXES include/SDL2 include SDL2
+    i686-w64-mingw32/include/SDL2
+    PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /usr/local/include/SDL2
+    /usr/include/SDL2
+    /sw # Fink
+    /opt/local # DarwinPorts
+    /opt/csw # Blastwave
+    /opt
 )
 
 # Lookup the 64 bit libs on x64
 IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	FIND_LIBRARY(SDL2_NET_LIBRARY_TEMP
-		NAMES SDL2_net
-		HINTS
-		${SDL2}
-		$ENV{SDL2}
-		$ENV{SDL2_NET}
-		PATH_SUFFIXES lib64 lib
-		lib/x64
-		x86_64-w64-mingw32/lib
-		PATHS
-		/sw
-		/opt/local
-		/opt/csw
-		/opt
-	)
+    FIND_LIBRARY(SDL2_NET_LIBRARY_TEMP
+        NAMES SDL2_net
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_NET}
+        PATH_SUFFIXES lib64 lib
+        lib/x64
+        x86_64-w64-mingw32/lib
+        PATHS
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+    )
 # On 32bit build find the 32bit libs
-ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	FIND_LIBRARY(SDL2_NET_LIBRARY_TEMP
-		NAMES SDL2_net
-		HINTS
-		${SDL2}
-		$ENV{SDL2}
-		$ENV{SDL2_NET}
-		PATH_SUFFIXES lib
-		lib/x86
-		i686-w64-mingw32/lib
-		PATHS
-		/sw
-		/opt/local
-		/opt/csw
-		/opt
-	)
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    FIND_LIBRARY(SDL2_NET_LIBRARY_TEMP
+        NAMES SDL2_net
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_NET}
+        PATH_SUFFIXES lib
+        lib/x86
+        i686-w64-mingw32/lib
+        PATHS
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+    )
 ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 SET(SDL2_NET_FOUND "NO")
-	IF(SDL2_NET_LIBRARY_TEMP)
-	# Set the final string here so the GUI reflects the final state.
-	SET(SDL2_NET_LIBRARY ${SDL2_NET_LIBRARY_TEMP} CACHE STRING "Where the SDL2_net Library can be found")
-	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
-	SET(SDL2_NET_LIBRARY_TEMP "${SDL2_NET_LIBRARY_TEMP}" CACHE INTERNAL "")
-	SET(SDL2_NET_FOUND "YES")
+    IF(SDL2_NET_LIBRARY_TEMP)
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2_NET_LIBRARY ${SDL2_NET_LIBRARY_TEMP} CACHE STRING "Where the SDL2_net Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2_NET_LIBRARY_TEMP "${SDL2_NET_LIBRARY_TEMP}" CACHE INTERNAL "")
+    SET(SDL2_NET_FOUND "YES")
 ENDIF(SDL2_NET_LIBRARY_TEMP)
 
 INCLUDE(FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_NET REQUIRED_VARS SDL2_NET_LIBRARY SDL2_NET_INCLUDE_DIR)
-

--- a/tests/0050_GUI_View/_cmake/CMakeLists.txt
+++ b/tests/0050_GUI_View/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -27,6 +27,6 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_shapes.cpp
 ../../../SDL2_gui/GUI_View.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0060_GUI_LayoutAlign/_cmake/CMakeLists.txt
+++ b/tests/0060_GUI_LayoutAlign/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -30,8 +30,9 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_image.cpp
 ../../../SDL2_gui/GUI_TextView.cpp
 ../../../SDL2_gui/GUI_Fonts.cpp
-../../../SDL2_gui/GUI_IconView.cpp)
+../../../SDL2_gui/GUI_IconView.cpp
+../../../SDL2_gui/GUI_Config.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0060_GUI_LayoutAlign/src/main.cpp
+++ b/tests/0060_GUI_LayoutAlign/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
         SDL_LogError( SDL_LOG_CATEGORY_ERROR, "Hello, World!\n" );
         exit(1);
     }
-    
+
     if (TTF_Init() != 0) {
         GUI_Log("TTF_Init failed.");
         SDL_Quit();
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
     // Create Window
     SDL_Log("request: %d %d\n", expectedWidth, expectedHeight);
     GUI_Init(title, expectedWidth, expectedHeight );
-    
+
 #if defined(WIN32)
     GUI_SetWindowIcon(IDI_ICON1);
 #endif
@@ -50,9 +50,9 @@ int main(int argc, char *argv[]) {
     topView->setMargin(10, 10, 10, 10);
     topView->setPadding(5, 5, 5, 5);
 
-    createAbsoluteViews();
+//    createAbsoluteViews();
     createHorizontalViews();
-    createVerticalViews();
+//    createVerticalViews();
 
     GUI_Run();
     GUI_Destroy();
@@ -73,15 +73,15 @@ void createAbsoluteViews() {
     vGrey->dragable = true;
     vGrey->click_to_top = true;
 
-    
-    GUI_TextView *vRedX = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
+
+    GUI_TextView *vRedX = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 100, 100 );
     vRedX->setBackgroundColor( cRed );
     vRedX->dragable = true;
     vRedX->setAlign( GUI_ALIGN_TOP | GUI_ALIGN_LEFT );
     vRedX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_LEFT );
     vRedX->setMargin( 5, 5, 5, 5 );
     vRedX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX->setBackgroundColor( cGreen );
     vGreenX->dragable = true;
@@ -89,7 +89,7 @@ void createAbsoluteViews() {
     vGreenX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_CENTER );
     vGreenX->setMargin( 5, 5, 5, 5 );
     vGreenX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX->setBackgroundColor( cBlue );
     vBlueX->dragable = true;
@@ -97,7 +97,7 @@ void createAbsoluteViews() {
     vBlueX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_RIGHT );
     vBlueX->setMargin( 5, 5, 5, 5 );
     vBlueX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vRedX2 = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX2->setBackgroundColor( cRed );
     vRedX2->dragable = true;
@@ -105,7 +105,7 @@ void createAbsoluteViews() {
     vRedX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_LEFT );
     vRedX2->setMargin( 5, 5, 5, 5 );
     vRedX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX2 = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX2->setBackgroundColor( cGreen );
     vGreenX2->dragable = true;
@@ -113,7 +113,7 @@ void createAbsoluteViews() {
     vGreenX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_CENTER );
     vGreenX2->setMargin( 5, 5, 5, 5 );
     vGreenX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX2 = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX2->setBackgroundColor( cBlue );
     vBlueX2->dragable = true;
@@ -121,7 +121,7 @@ void createAbsoluteViews() {
     vBlueX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_RIGHT );
     vBlueX2->setMargin( 5, 5, 5, 5 );
     vBlueX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vRedX3 = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX3->setBackgroundColor( cRed );
     vRedX3->dragable = true;
@@ -129,7 +129,7 @@ void createAbsoluteViews() {
     vRedX3->setContentAlign( GUI_ALIGN_BOTTOM | GUI_ALIGN_LEFT );
     vRedX3->setMargin( 5, 5, 5, 5 );
     vRedX3->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX3 = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX3->setBackgroundColor( cGreen );
     vGreenX3->dragable = true;
@@ -137,7 +137,7 @@ void createAbsoluteViews() {
     vGreenX3->setContentAlign( GUI_ALIGN_BOTTOM | GUI_ALIGN_CENTER );
     vGreenX3->setMargin( 5, 5, 5, 5 );
     vGreenX3->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX3 = GUI_TextView::create( vGrey, "ไก่กี่ปีเป่าปี่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX3->setBackgroundColor( cBlue );
     vBlueX3->dragable = true;
@@ -155,7 +155,7 @@ void createHorizontalViews() {
     vGrey->setLayout( GUI_LAYOUT_HORIZONTAL );
     vGrey->dragable = true;
     vGrey->click_to_top = true;
-    
+
     GUI_TextView *vRedX = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX->setBackgroundColor( cRed );
     vRedX->dragable = true;
@@ -163,7 +163,7 @@ void createHorizontalViews() {
     vRedX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_LEFT );
     vRedX->setMargin( 5, 5, 5, 5 );
     vRedX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX->setBackgroundColor( cGreen );
     vGreenX->dragable = true;
@@ -171,7 +171,7 @@ void createHorizontalViews() {
     vGreenX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_CENTER );
     vGreenX->setMargin( 5, 5, 5, 5 );
     vGreenX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX->setBackgroundColor( cBlue );
     vBlueX->dragable = true;
@@ -179,7 +179,7 @@ void createHorizontalViews() {
     vBlueX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_RIGHT );
     vBlueX->setMargin( 5, 5, 5, 5 );
     vBlueX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vRedX2 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX2->setBackgroundColor( cRed );
     vRedX2->dragable = true;
@@ -187,7 +187,7 @@ void createHorizontalViews() {
     vRedX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_LEFT );
     vRedX2->setMargin( 5, 5, 5, 5 );
     vRedX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX2 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX2->setBackgroundColor( cGreen );
     vGreenX2->dragable = true;
@@ -195,7 +195,7 @@ void createHorizontalViews() {
     vGreenX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_CENTER );
     vGreenX2->setMargin( 5, 5, 5, 5 );
     vGreenX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX2s = GUI_TextView::create( vGrey, "ไก่กา", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX2s->setBackgroundColor( cGreen );
     vGreenX2s->dragable = true;
@@ -203,7 +203,7 @@ void createHorizontalViews() {
     vGreenX2s->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_CENTER );
     vGreenX2s->setMargin( 5, 5, 5, 5 );
     vGreenX2s->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX2 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX2->setBackgroundColor( cBlue );
     vBlueX2->dragable = true;
@@ -211,7 +211,7 @@ void createHorizontalViews() {
     vBlueX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_RIGHT );
     vBlueX2->setMargin( 5, 5, 5, 5 );
     vBlueX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vRedX3 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX3->setBackgroundColor( cRed );
     vRedX3->dragable = true;
@@ -219,7 +219,7 @@ void createHorizontalViews() {
     vRedX3->setContentAlign( GUI_ALIGN_BOTTOM | GUI_ALIGN_LEFT );
     vRedX3->setMargin( 5, 5, 5, 5 );
     vRedX3->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX3 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX3->setBackgroundColor( cGreen );
     vGreenX3->dragable = true;
@@ -227,7 +227,7 @@ void createHorizontalViews() {
     vGreenX3->setContentAlign( GUI_ALIGN_BOTTOM | GUI_ALIGN_CENTER );
     vGreenX3->setMargin( 5, 5, 5, 5 );
     vGreenX3->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX3 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX3->setBackgroundColor( cBlue );
     vBlueX3->dragable = true;
@@ -246,7 +246,7 @@ void createVerticalViews() {
     vGrey->dragable = true;
     vGrey->click_to_top = true;
 
-    
+
     GUI_TextView *vRedX = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX->setBackgroundColor( cRed );
     vRedX->dragable = true;
@@ -254,7 +254,7 @@ void createVerticalViews() {
     vRedX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_LEFT );
     vRedX->setMargin( 5, 5, 5, 5 );
     vRedX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX->setBackgroundColor( cGreen );
     vGreenX->dragable = true;
@@ -262,7 +262,7 @@ void createVerticalViews() {
     vGreenX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_CENTER );
     vGreenX->setMargin( 5, 5, 5, 5 );
     vGreenX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX->setBackgroundColor( cBlue );
     vBlueX->dragable = true;
@@ -270,7 +270,7 @@ void createVerticalViews() {
     vBlueX->setContentAlign( GUI_ALIGN_TOP | GUI_ALIGN_RIGHT );
     vBlueX->setMargin( 5, 5, 5, 5 );
     vBlueX->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vRedX2 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX2->setBackgroundColor( cRed );
     vRedX2->dragable = true;
@@ -278,7 +278,7 @@ void createVerticalViews() {
     vRedX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_LEFT );
     vRedX2->setMargin( 5, 5, 5, 5 );
     vRedX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX2 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX2->setBackgroundColor( cGreen );
     vGreenX2->dragable = true;
@@ -286,7 +286,7 @@ void createVerticalViews() {
     vGreenX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_CENTER );
     vGreenX2->setMargin( 5, 5, 5, 5 );
     vGreenX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX2s = GUI_TextView::create( vGrey, "ไก่กา", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX2s->setBackgroundColor( cGreen );
     vGreenX2s->dragable = true;
@@ -294,7 +294,7 @@ void createVerticalViews() {
     vGreenX2s->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_CENTER );
     vGreenX2s->setMargin( 5, 5, 5, 5 );
     vGreenX2s->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX2 = GUI_TextView::create( vGrey, "ไก่กา", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX2->setBackgroundColor( cBlue );
     vBlueX2->dragable = true;
@@ -302,7 +302,7 @@ void createVerticalViews() {
     vBlueX2->setContentAlign( GUI_ALIGN_VCENTER | GUI_ALIGN_RIGHT );
     vBlueX2->setMargin( 5, 5, 5, 5 );
     vBlueX2->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vRedX3 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vRedX3->setBackgroundColor( cRed );
     vRedX3->dragable = true;
@@ -310,7 +310,7 @@ void createVerticalViews() {
     vRedX3->setContentAlign( GUI_ALIGN_BOTTOM | GUI_ALIGN_LEFT );
     vRedX3->setMargin( 5, 5, 5, 5 );
     vRedX3->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vGreenX3 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vGreenX3->setBackgroundColor( cGreen );
     vGreenX3->dragable = true;
@@ -318,7 +318,7 @@ void createVerticalViews() {
     vGreenX3->setContentAlign( GUI_ALIGN_BOTTOM | GUI_ALIGN_CENTER );
     vGreenX3->setMargin( 5, 5, 5, 5 );
     vGreenX3->setPadding( 5, 5, 5, 5 );
-    
+
     GUI_TextView *vBlueX3 = GUI_TextView::create( vGrey, "ไก่", "Kanit-Light.ttf", 16, 0, 0, 0, 0 );
     vBlueX3->setBackgroundColor( cBlue );
     vBlueX3->dragable = true;

--- a/tests/0070_GUI_Label/_cmake/CMakeLists.txt
+++ b/tests/0070_GUI_Label/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -31,8 +31,9 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_TextView.cpp
 ../../../SDL2_gui/GUI_Fonts.cpp
 ../../../SDL2_gui/GUI_IconView.cpp
-../../../SDL2_gui/GUI_Label.cpp)
+../../../SDL2_gui/GUI_Label.cpp
+../../../SDL2_gui/GUI_Config.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0080_BasicControl/_cmake/CMakeLists.txt
+++ b/tests/0080_BasicControl/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -39,8 +39,9 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_List.cpp
 ../../../SDL2_gui/GUI_ScrollView.cpp
 ../../../SDL2_gui/GUI_EditText.cpp
-../../../SDL2_gui/GUI_TextUtil.cpp)
+../../../SDL2_gui/GUI_TextUtil.cpp
+../../../SDL2_gui/GUI_Config.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0090_Mouse_Touch/_cmake/CMakeLists.txt
+++ b/tests/0090_Mouse_Touch/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -49,8 +49,9 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_MessageBox.cpp
 ../../../SDL2_gui/GUI_Switch.cpp
 ../../../SDL2_gui/GUI_ComboBox.cpp
-../../../SDL2_gui/GUI_Slider.cpp)
+../../../SDL2_gui/GUI_Slider.cpp
+../../../SDL2_gui/GUI_Config.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0100_GUI_App/_cmake/CMakeLists.txt
+++ b/tests/0100_GUI_App/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -49,8 +49,9 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_MessageBox.cpp
 ../../../SDL2_gui/GUI_Switch.cpp
 ../../../SDL2_gui/GUI_ComboBox.cpp
-../../../SDL2_gui/GUI_Slider.cpp)
+../../../SDL2_gui/GUI_Slider.cpp
+../../../SDL2_gui/GUI_Config.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0110_UniversalApp/_cmake/CMakeLists.txt
+++ b/tests/0110_UniversalApp/_cmake/CMakeLists.txt
@@ -4,21 +4,21 @@ project(app)
 set(OUTFILE app)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__RPI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(SDL2)
 find_package(SDL2_IMAGE)
 find_package(HARFBUZZ)
 find_package(Freetype REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR} 
-${SDL2_IMAGE_INCLUDE_DIR} 
+include_directories(${SDL2_INCLUDE_DIR}
+${SDL2_IMAGE_INCLUDE_DIR}
 ${HARFBUZZ_INCLUDE_DIR}
 ${FREETYPE_INCLUDE_DIRS}
 ../../../SDL2_gui
 ../../../SDL2_gfx)
 
-set(SOURCE_FILES 
-../src/main.cpp 
+set(SOURCE_FILES
+../src/main.cpp
 ../../../SDL2_ttf_HarfBuzz/SDL_ttf.cpp
 ../../../SDL2_gfx/SDL2_gfxPrimitives.c
 ../../../SDL2_gfx/SDL2_rotozoom.c
@@ -49,8 +49,9 @@ set(SOURCE_FILES
 ../../../SDL2_gui/GUI_MessageBox.cpp
 ../../../SDL2_gui/GUI_Switch.cpp
 ../../../SDL2_gui/GUI_ComboBox.cpp
-../../../SDL2_gui/GUI_Slider.cpp)
+../../../SDL2_gui/GUI_Slider.cpp
+../../../SDL2_gui/GUI_Config.cpp)
 add_executable(${OUTFILE} ${SOURCE_FILES})
-target_link_libraries(${OUTFILE} ${SDL2_LIBRARY} 
+target_link_libraries(${OUTFILE} ${SDL2_LIBRARY}
 ${SDL2_IMAGE_LIBRARY} ${HARFBUZZ_LIBRARY}
 ${FREETYPE_LIBRARIES})

--- a/tests/0112_MobileApp/src/App.cpp
+++ b/tests/0112_MobileApp/src/App.cpp
@@ -1,0 +1,281 @@
+#include <algorithm>
+#include "App.h"
+#include "AbstractWindow.h"
+#include "Tools.h"
+
+using namespace std;
+
+App* App::instance = nullptr;
+
+App* App::create(std::string aTitle, int aExpectedWidth, int aExpectedHeight
+    , int aOrientation, int aOptions)
+{
+#if defined( __ANDROID__ )
+    int _orientation = 0; //GUI_ORIENTATION_PORTRAIT | GUI_ORIENTATION_LANDSCAPE;
+    if( SDL_IsTablet() ) {
+        GUI_Log( "Android: is Tablet\n" );
+        _expectedWidth = 480;
+        _expectedHeight = 800;
+    }
+    else {
+        GUI_Log( "Android: is Phone\n" );
+    }
+#elif defined( __EMSCRIPTEN__ )
+    _expectedWidth = -1;
+    _expectedHeight = -1;
+    int _orientation = 0;
+#else
+    int _orientation = GUI_ORIENTATION_PORTRAIT | GUI_ORIENTATION_LANDSCAPE;
+#endif
+    if(aExpectedWidth == 0)
+        aExpectedWidth = _expectedWidth;
+    if(aExpectedHeight == 0)
+        aExpectedHeight = _expectedHeight;
+    if(aOrientation == 0)
+        aOrientation = _orientation;
+
+    if(instance)
+        return instance;
+
+    App* lApp = new App(aOrientation, aTitle, aExpectedWidth, aExpectedHeight
+        , aOptions);
+
+    if(lApp->topView == nullptr)
+    {
+        delete lApp;
+        lApp = nullptr;
+    }
+
+    GUI_App::instance = instance = lApp;
+    return lApp;
+}
+
+App::App(int aOrientation, std::string aTitle, int aExpectedWidth
+    , int aExpectedHeight, int aOptions)
+    : GUI_App(aOrientation, aTitle, aExpectedWidth, aExpectedHeight, aOptions)
+{
+    createBackButton(aOptions);
+    createSystemMenu(aOptions);
+
+    if(menuView)
+    {
+        menuView->setCallback(std::bind(&App::systemMenuClicked, this
+            , std::placeholders::_1));
+        menuView->callback_on_mouse_down = true;
+    }
+}
+
+App::~App()
+{
+    for(auto w : mWindows)
+        delete w;
+    mWindows.clear();
+}
+
+void App::createSystemMenu(int aOptions)
+{
+    mSystemMenu.push_back(menuView->addSimpleMenu(tr("About app...")));
+    mSystemMenu.push_back(menuView->addSimpleMenu(tr("Quit"), true));
+}
+
+void App::createBackButton(int aOptions)
+{
+    if(mBackButton)
+        return;
+    int lAlign(GUI_ALIGN_VCENTER);
+    if((aOptions & GUI_APP_MENU_LEFT) || (aOptions & GUI_APP_MENU_LEFT_TOP)
+        || (aOptions & GUI_APP_MENU_LEFT_BOTTOM))
+        lAlign |= GUI_ALIGN_RIGHT;
+    else
+        lAlign |= GUI_ALIGN_LEFT;
+
+    mBackButton = GUI_Button::create(topBar->contentView, NULL
+        , kIcon_solid_arrow_left, 0, 0, 0, 0
+        , std::bind(&App::backButtonCallback, this, std::placeholders::_1));
+    mBackButton->setBorder(0);
+    mBackButton->setMargin(0, 0, 0, 5);
+    mBackButton->setAlign(lAlign);
+    mBackButton->setBackgroundColor(cClear);
+    mBackButton->showInteract = false;
+}
+
+void App::addWindow(AbstractWindow* aWin)
+{
+    if(!aWin)
+        return;
+
+    if(static_cast<void*>(contentView) != static_cast<void*>(mWindows.back()))
+    {
+        topView->remove_child(contentView);
+        delete contentView;
+        contentView = nullptr;
+    }
+
+    // Remove window and system menu
+    for(auto i : mSystemMenu)
+        menuView->remove(i);
+    removeWindowMenu(mWindows.back());
+
+    topView->remove_child(mWindows.back());
+
+    // Add window and system menu
+    addWindowMenu(aWin);
+    for(auto i : mSystemMenu)
+    {
+        menuView->add(i);
+        i->setCallback(std::bind(&App::menuItemClicked, this
+                                 , std::placeholders::_1));
+    }
+
+    menuView->updateLayout();
+
+    mWindows.push_back(aWin);
+    contentView = aWin;
+
+    topView->add_child(aWin);
+
+    if(menuView)
+        menuView->toTop();
+
+    mBackButton->setEnable(mWindows.size() > 1);
+
+    topView->updateLayout();
+}
+
+void App::closeWindow(AbstractWindow* aWin)
+{
+    if(!aWin)
+        return;
+
+    AbstractWindow* lNextWindow(nullptr);
+    if(contentView && (contentView != aWin))
+    {
+        cerr << tr("Window stack broken!") << std::endl;
+
+        removeWindowMenu(aWin);
+        delete aWin;
+
+        while(AbstractWindow* w = mWindows.back())
+        {
+            topView->remove_child(w);
+            mWindows.pop_back();
+            if((contentView == w) || (mWindows.size() == 1))
+            {
+                lNextWindow = mWindows.back();
+                break;
+            }
+        }
+    }
+    if(contentView != lNextWindow)
+    {
+        AbstractWindow* lWin(dynamic_cast<AbstractWindow*>(contentView));
+        if(lWin)
+            removeWindowMenu(lWin);
+        topView->remove_child(contentView);
+        delete contentView;
+        contentView = 0;
+        mWindows.pop_back();
+    }
+    if(!lNextWindow && mWindows.size())
+        lNextWindow = mWindows.back();
+
+    if(contentView != lNextWindow)
+    {
+        addWindowMenu(lNextWindow);
+        contentView = lNextWindow;
+        topView->add_child(contentView);
+    }
+
+    mBackButton->setEnable(mWindows.size() > 1);
+
+    if(menuView)
+        menuView->toTop();
+
+    topView->updateLayout();
+}
+
+void App::addWindowMenu(AbstractWindow* aWin)
+{
+    if(!aWin)
+        return;
+
+    auto lWinMenu = aWin->menu();
+    for(auto i : lWinMenu)
+    {
+        i->separator = (i == lWinMenu.back());
+        menuView->add(i);
+        i->setCallback(std::bind(&App::menuItemClicked, this
+                                 , std::placeholders::_1));
+    }
+
+    menuView->updateLayout();
+}
+
+void App::removeWindowMenu(AbstractWindow* aWin)
+{
+    if(!aWin)
+        return;
+
+    auto lWinMenu = aWin->menu();
+    for(auto i : lWinMenu)
+        menuView->remove(i);
+
+    menuView->updateLayout();
+}
+
+void App::backButtonCallback(GUI_View* aButton)
+{
+    if(mWindows.size() <= 1)
+        return;
+    closeWindow(mWindows.back());
+}
+
+void App::menuItemClicked(GUI_View *aItem)
+{
+    GUI_MenuItem* lItem(dynamic_cast<GUI_MenuItem*>(aItem));
+    if(!lItem)
+        return;
+
+    lItem->setSelected(true);
+
+    for(vector<GUI_MenuItem *>::iterator it =
+        menuView->menuItems.begin();
+        it != menuView->menuItems.end(); ++it)
+    {
+        if((*it) != lItem)
+            (*it)->setSelected(false);
+    }
+}
+
+void App::systemMenuClicked(GUI_View* aMenu)
+{
+    GUI_Menu* lMenu = dynamic_cast<GUI_Menu*>(aMenu);
+    if(!lMenu)
+        return;
+    auto lItem(lMenu->selectedItem);
+    if(!lItem)
+        return;
+
+    if(find(mSystemMenu.begin(), mSystemMenu.end(), lItem)
+        != mSystemMenu.end())
+    {
+        systemMenuItemClicked(lItem);
+    }
+    else
+        mWindows.back()->menuItemClicked(lItem);
+
+    lMenu->close(GUI_AppMenuCollapseTime);
+}
+
+void App::systemMenuItemClicked(GUI_MenuItem *aItem)
+{
+    int lCounter(0);
+    for(auto i : mSystemMenu)
+    {
+        if((lCounter == 0) && (i == aItem))
+            mWindows.back()->createPopup(tr("This is fancy mobile demo app!"));
+        else if((lCounter == 1) && (i == aItem))
+            exit(EXIT_SUCCESS);
+        ++lCounter;
+    }
+}

--- a/tests/0112_MobileApp/src/App.h
+++ b/tests/0112_MobileApp/src/App.h
@@ -1,0 +1,37 @@
+#ifndef APP_H
+#define APP_H
+
+#include "GUI_App.h"
+
+class AbstractWindow;
+
+class App : public GUI_App
+{
+public:
+    static App* instance;
+    static App* create(std::string aTitle, int aExpectedWidth = 0
+        , int aExpectedHeight = 0, int aOrientation = 0, int aOptions = 0);
+    App(int aOrientation, std::string aTitle, int aExpectedWidth = 0
+            , int aExpectedHeight = 0, int aOptions = 0);
+    ~App();
+public:
+    void addWindow(AbstractWindow* aWin);
+    void closeWindow(AbstractWindow* aWin);
+protected:
+    virtual void createSystemMenu(int aOptions);
+    void createBackButton(int aOptions);
+    void addWindowMenu(AbstractWindow* aWin);
+    void removeWindowMenu(AbstractWindow* aWin);
+    void backButtonCallback(GUI_View* aButton);
+    void menuItemClicked(GUI_View *aItem);
+    void systemMenuClicked(GUI_View *aMenu);
+    void systemMenuItemClicked(GUI_MenuItem* aItem);
+public:
+    std::list<AbstractWindow*> mWindows;
+protected:
+    GUI_Button* mBackButton = nullptr;
+    std::list<GUI_MenuItem*> mSystemMenu;   // These buttons are always below
+                                            // window buttons
+};
+
+#endif // APP_H

--- a/tests/0112_MobileApp/src/ContactEdit.cpp
+++ b/tests/0112_MobileApp/src/ContactEdit.cpp
@@ -1,0 +1,117 @@
+#include <string>
+#include "ContactEdit.h"
+#include "Tools.h"
+#include "MainWindow.h"
+#include "App.h"
+#include "ListItem.h"
+
+using namespace std;
+
+ContactEdit* ContactEdit::create(ContactPtr aContact, GUI_View *aParent
+    , const char *aTitle, int x, int y, int aWidth
+    , int aHeight, std::function<bool(SDL_Event* ev)> aUserEventHandler)
+{
+    return new ContactEdit(aContact, aParent, aTitle, x, y, aWidth, aHeight,
+        aUserEventHandler);
+}
+
+ContactEdit::ContactEdit(ContactPtr aContact, GUI_View *aParent
+    , const char *aTitle, int x, int y, int aWidth, int aHeight
+    , std::function<bool(SDL_Event* ev)> aUserEventHandler)
+    : AbstractWindow(aParent, aTitle, x, y, aWidth, aHeight, aUserEventHandler)
+    , mContact(aContact)
+{
+    createWindowMenu();
+    createContent();
+}
+
+void ContactEdit::createContent()
+{
+    mNameLabel = GUI_Label::create(this, tr("Name:"));
+    mNameEdit = GUI_EditText::create(this, "", 0, 0, -1, 0);
+    mIconLabel = GUI_Label::create(this, tr("Icon:"));
+    mIconEdit = GUI_EditText::create(this, "", 0, 0, -1, 0);
+    mMobileLabel = GUI_Label::create(this, tr("Mobile:"));
+    mMobileEdit = GUI_EditText::create(this, "", 0, 0, -1, 0);
+    mEmailLabel = GUI_Label::create(this, tr("Email:"));
+    mEmailEdit = GUI_EditText::create(this, "", 0, 0, -1, 0);
+    mAddressLabel = GUI_Label::create(this, tr("Addres:"));
+    mAddressEdit = GUI_EditText::create(this, "", 0, 0, -1, 0);
+    mChildCountLabel = GUI_Label::create(this, tr("Children counter:"));
+    mChildCountEdit = GUI_EditText::create(this, "", 0, 0, -1, 0);
+    fps = GUI_FPSView::create(this);
+    mSaveButton = GUI_Button::create(this, tr("Save contact"), kIcon_solid_edit, 0, 0, 0
+        , 0, [=](GUI_View* v)
+    {
+        this->saveContact();
+    });
+
+
+    withdrawChangesClicked(nullptr);
+}
+
+void ContactEdit::createWindowMenu()
+{
+    mMenu.push_back(addMenu(tr("Withdraw changes")));
+    mMenu.push_back(addMenu(tr("Clear data")));
+    mMenu.push_back(addMenu(tr("Delete contact")));
+}
+
+void ContactEdit::menuItemClicked(GUI_MenuItem* aItem)
+{
+    int lCounter(0);
+    for(auto i : mMenu)
+    {
+        if((lCounter == 0) && (i == aItem))
+            withdrawChangesClicked(aItem);
+        else if((lCounter == 1) && (i == aItem))
+            clearDataClicked(aItem);
+        else if((lCounter == 2) && (i == aItem))
+            deleteContactClicked(aItem);
+        ++lCounter;
+    }
+}
+
+void ContactEdit::withdrawChangesClicked(GUI_MenuItem* aItem)
+{
+    mNameEdit->setTitle(mContact->mName);
+    mIconEdit->setTitle(mContact->mIcon);
+    mMobileEdit->setTitle(mContact->mMobile);
+    mEmailEdit->setTitle(mContact->mEmail);
+    mAddressEdit->setTitle(mContact->mAddress);
+    mChildCountEdit->setTitle(to_string(mContact->mChildCount));
+}
+
+void ContactEdit::clearDataClicked(GUI_MenuItem* aItem)
+{
+    mNameEdit->setTitle("");
+    mIconEdit->setTitle("");
+    mMobileEdit->setTitle("");
+    mEmailEdit->setTitle("");
+    mAddressEdit->setTitle("");
+    mChildCountEdit->setTitle(to_string(0));
+}
+
+void ContactEdit::deleteContactClicked(GUI_MenuItem* aItem)
+{
+    MainWindow::instance->deleteContactClicked(aItem);
+}
+
+void ContactEdit::saveContact()
+{
+    mContact->mName = mNameEdit->title;
+    mContact->mIcon = mIconEdit->title;
+    mContact->mMobile = mMobileEdit->title;
+    mContact->mEmail = mEmailEdit->title;
+    mContact->mAddress = mAddressEdit->title;
+    mContact->mChildCount = std::stoi(mChildCountEdit->title);
+    App::instance->closeWindow(this);
+    MainWindow* lWin(dynamic_cast<MainWindow*>
+        (App::instance->mWindows.front()));
+    if(!lWin)
+        return;
+    ListItem* lItem(dynamic_cast<ListItem*>(lWin->mContactList->selectedItem));
+    if(!lItem)
+        return;
+    lItem->updateData();
+}

--- a/tests/0112_MobileApp/src/ContactEdit.h
+++ b/tests/0112_MobileApp/src/ContactEdit.h
@@ -1,0 +1,50 @@
+#ifndef CONTACTEDIT_H
+#define CONTACTEDIT_H
+
+#include "SDL_gui.h"
+#include "AbstractWindow.h"
+#include "Contact.h"
+
+class MainWindow;
+
+class ContactEdit : public AbstractWindow
+{
+public:
+    static ContactEdit* create(ContactPtr aContact, GUI_View *aParent
+        , const char *aTitle, int x = 0, int y = 0
+        , int aWidth = 0, int aHeight = 0
+        , std::function<bool(SDL_Event* ev)> aUserEventHandler = nullptr);
+    ContactEdit(ContactPtr aContact, GUI_View *aParent, const char *aTitle
+        , int x = 0, int y = 0, int aWidth = 0
+        , int aHeight = 0
+        , std::function<bool(SDL_Event* ev)> aUserEventHandler = nullptr);
+
+    void createContent();
+
+    GUI_Label* mNameLabel = nullptr;
+    GUI_EditText* mNameEdit = nullptr;
+    GUI_Label* mIconLabel = nullptr;
+    GUI_EditText* mIconEdit = nullptr;
+    GUI_Label* mMobileLabel = nullptr;
+    GUI_EditText* mMobileEdit = nullptr;
+    GUI_Label* mEmailLabel = nullptr;
+    GUI_EditText* mEmailEdit = nullptr;
+    GUI_Label* mAddressLabel = nullptr;
+    GUI_EditText* mAddressEdit = nullptr;
+    GUI_Label* mChildCountLabel = nullptr;
+    GUI_EditText* mChildCountEdit = nullptr;
+    GUI_Button* mSaveButton = nullptr;
+    GUI_FPSView *fps = nullptr;
+
+protected:
+    void createWindowMenu();
+    void menuItemClicked(GUI_MenuItem* aItem);
+    void withdrawChangesClicked(GUI_MenuItem* aItem);
+    void clearDataClicked(GUI_MenuItem* aItem);
+    void deleteContactClicked(GUI_MenuItem* aItem);
+    void saveContact();
+protected:
+    ContactPtr mContact;
+};
+
+#endif // CONTACTEDIT_H

--- a/tests/0112_MobileApp/src/MobileAppDefinitions.h
+++ b/tests/0112_MobileApp/src/MobileAppDefinitions.h
@@ -1,0 +1,11 @@
+#ifndef MOBILEAPPDEFINITIONS_H
+#define MOBILEAPPDEFINITIONS_H
+
+#include <string>
+
+static std::string gProgramName = "";
+const std::string gProgramVersion = "0.1";
+const std::string gOrganization = "Energo Kod";
+const std::string gAuthor = "Szyk Cech";
+const std::string gContact = "szykcech@spoko.pl";
+#endif // MOBILEAPPDEFINITIONS_H

--- a/tests/0112_MobileApp/src/Tools.cpp
+++ b/tests/0112_MobileApp/src/Tools.cpp
@@ -1,0 +1,57 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <linux/limits.h>
+#include <iostream>
+#include <string.h>
+#include "Tools.h"
+
+std::string gTranslationDir(std::string aExePath)
+{
+    std::string lResult, lTransSubDir("/Translations");
+    // We check exe path dir
+    struct stat lInfo;
+    if(stat(aExePath.c_str(), &lInfo) != 0)
+        std::cerr << tr("stat() failed for path: ") << aExePath << tr(" error: ") << strerror(errno);
+    else if(S_ISREG(lInfo.st_mode) && (lInfo.st_mode & S_IXUSR))
+    {
+        lResult = aExePath.substr(0, aExePath.find_last_of('/') + 1) + lTransSubDir;
+        if(stat(lResult.c_str(), &lInfo) != 0)
+            std::cerr << tr("stat() failed for path: ") << lResult << tr(" error: ") << strerror(errno);
+        else if(S_ISDIR(lInfo.st_mode))
+            return lResult;
+    }
+    else if(S_ISDIR(lInfo.st_mode))
+    {
+        lResult = aExePath + lTransSubDir;
+        if(stat(lResult.c_str(), &lInfo) != 0)
+            std::cerr << tr("stat() failed for path: ") << lResult << tr(" error: ") << strerror(errno);
+        else if(S_ISDIR(lInfo.st_mode))
+            return lResult;
+    }
+
+    // We check current working directory
+    char lCwd[PATH_MAX];
+    getcwd(lCwd, PATH_MAX);
+    lResult = lCwd;
+    lResult += lTransSubDir;
+    if(stat(lResult.c_str(), &lInfo) != 0)
+        std::cerr << tr("stat() failed for path: ") << lResult << tr(" error: ") << strerror(errno);
+    else if(S_ISDIR(lInfo.st_mode))
+        return lResult;
+
+    // We check /usr/local/share/PROGRAM_NAME/Translations
+    lResult = "/usr/local/share/";
+    lResult += aExePath.substr(aExePath.find_last_of('/') + 1) + lTransSubDir;
+    if(stat(lResult.c_str(), &lInfo) != 0)
+        std::cerr << tr("stat() failed for path: ") << lResult << tr(" error: ") << strerror(errno);
+    else if(S_ISDIR(lInfo.st_mode))
+        return lResult;
+    return "";
+}
+
+std::string gGetProgramName(std::string aExePath)
+{
+    return aExePath.substr(aExePath.find_last_of('/') + 1);
+}

--- a/tests/0112_MobileApp/src/Tools.h
+++ b/tests/0112_MobileApp/src/Tools.h
@@ -1,0 +1,14 @@
+#ifndef TOOLS_H
+#define TOOLS_H
+
+#include <string>
+#include <libintl.h>
+#include <locale.h>
+
+#define tr(String) gettext (String)
+
+std::string gTranslationDir(std::string aExePath);
+std::string gGetProgramName(std::string aExePath);
+
+
+#endif // TOOLS_H


### PR DESCRIPTION
In this branch I write:
1. Nice menu animations (acording to menu button alignment and explicit settings): from left (it was done by mozeal), from right, from top and from bottom
2. Gradient for GUI_View based widgets. Gradient can be vertical or horizontal. Widget rounded corners are respected.
3. Texture background for GUI_View based widgets. Texture is tiled from left to right row by row. Widget rounded corners are respected.

I also fix some bugs. Most notable are:
- rpi definitions in `CMakeLists.txt` (cause gui events not works at least under Linux) - this was reason why at first I thought you don't wrote interactive examples.
- [NOT ALL FIXED:] 32 bit detection in ./tests/XXX/_cmake/modules/XXX.cmake have lines like this:
```
# On 32bit build find the 32bit libs
ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)

```
which is obiously wrong. It should be like this:
```
# On 32bit build find the 32bit libs
ELSE(CMAKE_SIZEOF_VOID_P EQUAL 4)

```

- Instead just:
`#include <SDL.h>`
I correct it:
`#include <SDL2/SDL.h>`